### PR TITLE
Fix: update news card dummy image source #306

### DIFF
--- a/src/lib/components/NewsComponent/NewsComponent.svelte
+++ b/src/lib/components/NewsComponent/NewsComponent.svelte
@@ -1,25 +1,26 @@
 <script>
+	import placeholder from '$lib/assets/images/placeholder2.jpg'
 	const NewsCards = [
 		{
 			id: 1,
 			title: 'XRISM ziet verrassend trage en dichte wind van neutronenster',
 			type: 'News',
 			slug: '',
-			image: '/src/lib/assets/images/placeholder2.jpg',
+			image: placeholder,
 		},
 		{
 			id: 2,
 			title: 'SRON Open Dagen op 5 en 11 oktober 2025',
 			type: 'Event',
 			slug: '',
-			image: '/src/lib/assets/images/placeholder2.jpg',
+			image: placeholder,
 		},
 		{
 			id: 3,
 			title: 'Nieuw ontwerp verandert glanzend aluminium in een absorber om de eerste sterrenstelsels te observeren',
 			type: 'News',
 			slug: '',
-			image: '/src/lib/assets/images/placeholder2.jpg',
+			image: placeholder,
 		},
 	]
 </script>
@@ -30,7 +31,7 @@
 		{#each NewsCards as newscard}
 			<li class="news-card">
 				<img src={newscard.image} alt="" height="240" width="240" />
-				<h3 class=""><a href={newscard.slug}>{newscard.title}</a></h3>
+				<h3><a href={newscard.slug}>{newscard.title}</a></h3>
 				<p>{newscard.type}</p>
 			</li>
 		{/each}


### PR DESCRIPTION
## What does this change?

Resolves issue #306. Fixes image source being broken on the live build 🙂

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

I opened it in the browser and the images are correctly displaying!

## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Open it in the browser and check if there are images for you as well 👍

## Summary by Sourcery

Bug Fixes:
- Verhelp gebroken dummy-afbeeldingsbron voor nieuwskaarten door te verwijzen naar de geïmporteerde placeholder-asset in plaats van een hardgecodeerd pad.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix broken dummy image source for news cards by referencing the imported placeholder asset instead of a hard-coded path.

</details>