### PR TITLE
Feat: add cool focus and hover state :) #293

### DIFF
--- a/src/lib/components/PillarsComponent.svelte
+++ b/src/lib/components/PillarsComponent.svelte
@@ -89,8 +89,7 @@
 		align-items: center;
 		grid-template-columns: clamp(1em, 30vw, 6.5em) 1fr;
 		width: 100%;
-
-		background-color: #292e6b;
+		overflow: hidden;
 
 		@media (min-width: 600px) {
 			display: flex;
@@ -109,6 +108,9 @@
 		height: 100%;
 		aspect-ratio: 1 / 1;
 		object-fit: cover;
+		transition: 0.3s;
+		position: relative;
+		z-index: -1;
 
 		@media (min-width: 600px) {
 			max-height: unset;
@@ -120,18 +122,35 @@
 		text-align: center;
 		font-size: clamp(1em, 5vw, 1.2em);
 		font-family: var(--heading);
+		width: 100%;
+		background-color: #292e6b;
 
 		@media (min-width: 600px) {
 			padding-block-start: 1em;
 			padding-block-end: 1em;
-			text-align: start;
 			font-size: unset;
 			text-wrap: nowrap;
 		}
 	}
 
-	.pillar:hover {
+	.pillar:hover,
+	.pillar:focus-within {
 		text-decoration: underline;
+
+		@media (min-width: 600px) {
+			img {
+				transform: scale(1.15);
+				transition: 0.3s;
+			}
+		}
+
+		a:focus-visible {
+			outline: none;
+		}
+	}
+
+	.pillar:focus-within {
+		outline: 0.125rem dashed var(--cleanroom-140);
 	}
 
 	a::after {
@@ -141,5 +160,6 @@
 		right: 0;
 		top: 0;
 		bottom: 0;
+		z-index: 1;
 	}
 </style>

--- a/src/lib/components/PillarsComponent.svelte
+++ b/src/lib/components/PillarsComponent.svelte
@@ -144,7 +144,6 @@
 		@media (min-width: 600px) {
 			img {
 				transform: scale(1.15);
-				transition: 0.3s;
 			}
 		}
 

--- a/src/lib/components/PillarsComponent.svelte
+++ b/src/lib/components/PillarsComponent.svelte
@@ -134,6 +134,7 @@
 			padding-block-end: 1em;
 			font-size: unset;
 			text-wrap: nowrap;
+			height: auto;
 		}
 	}
 

--- a/src/lib/components/PillarsComponent.svelte
+++ b/src/lib/components/PillarsComponent.svelte
@@ -119,11 +119,15 @@
 	}
 
 	.pillar a {
-		text-align: center;
 		font-size: clamp(1em, 5vw, 1.2em);
 		font-family: var(--heading);
 		width: 100%;
+		height: 100%;
 		background-color: #292e6b;
+
+		display: flex;
+		align-items: center;
+		justify-content: center;
 
 		@media (min-width: 600px) {
 			padding-block-start: 1em;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 	// Components
 	import Hero from '$lib/components/molecules/Hero/Hero.svelte'
 	import News from '$lib/components/NewsComponent/NewsComponent.svelte'
-  import PillarsComponent from '$lib/components/PillarsComponent.svelte'
+	import PillarsComponent from '$lib/components/PillarsComponent.svelte'
 </script>
 
 <svelte:head>
@@ -59,7 +59,6 @@
 			5vw,
 			3.5rem
 		); /* TODO: make this the standard padding for sections in general.css */
-
 
 		@media (min-width: 1000px) {
 			grid-template-columns: 2fr 1fr;


### PR DESCRIPTION
## What does this change?

Resolves issue #293. Adds a cool hover and focus state to the pillars. Uses focus-within to display the focus style around the entire pillar, instead of just the link.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

Tested with keyboard navigation. It is not responsive since hover won't work on mobile anyway.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="514" height="324" alt="image" src="https://github.com/user-attachments/assets/ac6f49f5-d1ed-4e00-8eaa-c5e01b4864c4" />


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Check if it works on your device/browser. 
- Check if the code looks good.

## Summary by Sourcery

Verbeter de interactiestaten van pilaarcards voor beter hover- en toetsenbordfocus-gedrag.

Nieuwe features:
- Voeg hover- en `focus-within`-stijlen toe die pilaartekst onderstrepen en afbeeldingen schalen op grotere schermen.
- Pas een zichtbare gestippelde outline toe rond de volledige pilaar wanneer deze of de inhoud ervan toetsenbordfocus krijgt.

Verbeteringen:
- Verfijn de lay-out van pilaren door de afbeelding en de link het volledige kaartgebied te laten opvullen, zodat achtergrond en overflow consistent worden afgehandeld.
- Pas de stapelvolgorde (stacking order) aan zodat overlay- en focusstijlen correct boven pilaarafbeeldingen worden weergegeven.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve pillar card interaction states for better hover and keyboard focus behaviour.

New Features:
- Add hover and focus-within styles that underline pillar text and scale images on larger screens.
- Apply a visible dashed outline around the entire pillar when it or its contents receive keyboard focus.

Enhancements:
- Refine pillar layout by letting the image and link fill the full card area, ensuring consistent background and overflow handling.
- Adjust stacking order so overlay and focus styles layer correctly above pillar images.

</details>