### PR TITLE
Feat: replace newscard section dummy data with dynamic data #301

### DIFF
--- a/src/lib/components/NewsComponent/NewsComponent.svelte
+++ b/src/lib/components/NewsComponent/NewsComponent.svelte
@@ -1,37 +1,22 @@
 <script>
-	import placeholder from '$lib/assets/images/placeholder2.jpg'
-	const NewsCards = [
-		{
-			id: 1,
-			title: 'XRISM ziet verrassend trage en dichte wind van neutronenster',
-			type: 'News',
-			slug: '',
-			image: placeholder,
-		},
-		{
-			id: 2,
-			title: 'SRON Open Dagen op 5 en 11 oktober 2025',
-			type: 'Event',
-			slug: '',
-			image: placeholder,
-		},
-		{
-			id: 3,
-			title: 'Nieuw ontwerp verandert glanzend aluminium in een absorber om de eerste sterrenstelsels te observeren',
-			type: 'News',
-			slug: '',
-			image: placeholder,
-		},
-	]
+	import defaultImage from '$lib/assets/images/nebula-satellite.png'
+
+	let { newsCards } = $props()
 </script>
 
 <section>
 	<h2 class="section_title news_section_title">News, blogs & events</h2>
 	<ul class="news-grid">
-		{#each NewsCards as newscard}
+		{#each newsCards as newscard}
 			<li class="news-card">
-				<img src={newscard.image} alt="" height="240" width="240" />
-				<h3><a href={newscard.slug}>{newscard.title}</a></h3>
+				<img
+					src={newscard.image
+						? `https://fdnd-agency.directus.app/assets/${newscard.image}`
+						: defaultImage}
+					alt=""
+					height="240"
+					width="240" />
+				<h3><a href={`/news/${newscard.id}`}>{newscard.title}</a></h3>
 				<p>{newscard.type}</p>
 			</li>
 		{/each}

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -1,0 +1,10 @@
+import { DIRECTUS_NEWS } from '$env/static/private'
+
+export async function load({ url }) {
+	const limit = 3
+	const newsItemsResponse = await fetch(
+		`${DIRECTUS_NEWS}?sort=-date&limit=${limit}&fields=id,type,title,image`
+	).then((response) => response.json())
+
+	return { newsItems: newsItemsResponse.data }
+}

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -1,9 +1,8 @@
 import { DIRECTUS_NEWS } from '$env/static/private'
 
 export async function load({ url }) {
-	const limit = 3
 	const newsItemsResponse = await fetch(
-		`${DIRECTUS_NEWS}?sort=-date&limit=${limit}&fields=id,type,title,image`
+		`${DIRECTUS_NEWS}?sort=-date&limit=3&fields=id,type,title,image`
 	).then((response) => response.json())
 
 	return { newsItems: newsItemsResponse.data ?? [] }

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -6,5 +6,5 @@ export async function load({ url }) {
 		`${DIRECTUS_NEWS}?sort=-date&limit=${limit}&fields=id,type,title,image`
 	).then((response) => response.json())
 
-	return { newsItems: newsItemsResponse.data }
+	return { newsItems: newsItemsResponse.data ?? [] }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,8 @@
 	import Hero from '$lib/components/molecules/Hero/Hero.svelte'
 	import News from '$lib/components/NewsComponent/NewsComponent.svelte'
 	import PillarsComponent from '$lib/components/PillarsComponent.svelte'
+
+	let { data } = $props()
 </script>
 
 <svelte:head>
@@ -23,7 +25,7 @@
 	background={{ alt: 'Two merging black holes', file: heroImg }}
 	sronIcon={logo} />
 
-<News />
+<News newsCards={data.newsItems} />
 
 <section class="section-paragraph-picture">
 	<h2 class="section_title">Over Nebula Xplorer</h2>


### PR DESCRIPTION
## What does this change?

Resolves issue #301.
- Replaces dummy data used for the newscard section on the homepage with dynamic data from Directus.
- Adds a page.server.js to the root of the routes folder to fetch this data
- Limits the fields that are fetched to the id, type, title and image

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

Since there are no UI changes, I only tested if the data was being shown correctly.

## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
- Check if the code written is good and adheres to the conventions
- Check if the data is correctly displayed

## Summary by Sourcery

Vervang de hardgecodeerde kaarten in de nieuwssectie van de homepage door dynamisch opgehaalde items van Directus.

Nieuwe features:
- Laad nieuws-, blog- en evenementitems voor de homepage vanaf een Directus-endpoint via een nieuwe `+page.server.js` loader.

Verbeteringen:
- Werk de News-component en de homepage bij zodat ze dynamische gegevens voor nieuwskaarten kunnen accepteren en renderen, inclusief door Directus gehoste afbeeldingen met een fallback-asset en detaillinks op basis van item-ID’s.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the homepage news section’s hardcoded cards with dynamically fetched items from Directus.

New Features:
- Load news, blog, and event items for the homepage from a Directus endpoint via a new +page.server.js loader.

Enhancements:
- Update the News component and homepage to accept and render dynamic news card data, including Directus-hosted images with a fallback asset and detail links based on item IDs.

</details>