### PR TITLE
Feat: capitalize navigation links #291

### DIFF
--- a/src/lib/assets/styles/layout.css
+++ b/src/lib/assets/styles/layout.css
@@ -2,6 +2,7 @@
  */
 header.main-navigation {
 	font-family: SpaceGrotesk;
+	text-transform: capitalize;
 	display: flex;
 	background: transparent;
 	justify-content: flex-end;


### PR DESCRIPTION
## What does this change?

Resolves issue #291. Capitalizes links in the main navigation so that it matches the official sron website.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

I've briefly tested in Chrome if all menu items were correctly capitalized and if the navigation still worked like before.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
before:
<img width="982" height="129" alt="image" src="https://github.com/user-attachments/assets/9db928c3-5007-4e96-b280-ee2df8171392" />

after: 

<img width="972" height="135" alt="image" src="https://github.com/user-attachments/assets/29a945ee-fede-43a8-a910-3997d3d9fe59" />


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Check if the one line of code looks nice
- Check if it works correctly on your device/browser

## Summary by Sourcery

Verbeteringen:
- Pas de stijl van de hoofdnavigatiekop aan zodat alle navigatiekoppelingen in een gecapitalliseerde vorm worden weergegeven.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust main navigation header styling to render all navigation link text in capitalized form.

</details>