### PR TITLE
313 feature newscard component improved focus style

### DIFF
--- a/src/lib/components/NewsComponent/NewsComponent.svelte
+++ b/src/lib/components/NewsComponent/NewsComponent.svelte
@@ -114,7 +114,7 @@
 
 	.link-readmore {
 		display: block;
-		padding-block: 1rem 1rem;
+		padding-block: 1rem;
 		padding-inline: 1rem;
 		margin-block: 2rem 0;
 		margin-inline: auto;

--- a/src/lib/components/NewsComponent/NewsComponent.svelte
+++ b/src/lib/components/NewsComponent/NewsComponent.svelte
@@ -50,7 +50,6 @@
 	.news-card {
 		position: relative;
 		background-color: var(--white);
-		border-radius: 0.2rem;
 		box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.3);
 		transition:
 			transform 0.3s ease,
@@ -65,6 +64,8 @@
 		&:focus-within {
 			transform: translateY(-0.5rem);
 			box-shadow: 0 0 1rem rgba(0, 0, 0, 0.5);
+			outline: var(--default-focus);
+			outline-offset: 12px;
 		}
 	}
 
@@ -88,6 +89,10 @@
 		padding-block: 1rem;
 		padding-inline: clamp(0.75rem, 0.25rem + 1.1vw, 1rem);
 
+		a {
+			outline: none;
+		}
+
 		a::after {
 			content: '';
 			position: absolute;
@@ -109,8 +114,12 @@
 
 	.link-readmore {
 		display: block;
-		width: 100%;
-		padding-block: 2rem 1rem;
+		padding-block: 1rem 1rem;
+		padding-inline: 1rem;
+		margin-block: 2rem 0;
+		margin-inline: auto;
+		width: max-content;
+
 		font-family: var(--paragraph);
 		font-weight: 500;
 		text-align: center;


### PR DESCRIPTION
## What does this change?

Resolves issue #313. Updates the newscard focus style to encompass the entire card, instead of just the link within. Also adjusts the styling on the 'Read More' text so that the focus style looks prettier.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

Tested on Firefox and Chrome across all viewport sizes. 

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Before:
<img width="400" alt="Image" src="https://github.com/user-attachments/assets/7a30074a-a183-4b6c-b8f6-8edd778ea3d4" />

After:
<img width="696" height="564" alt="image" src="https://github.com/user-attachments/assets/a488965e-f3b8-4ba1-bfe8-45e852e9d209" />


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Check if it works on your device/browser
- Check if the code looks alright and if anything can be improved

## Summary by Sourcery

Verbeter de focus en visuele styling van de NewsCard‑component voor betere toegankelijkheid en leesbaarheid.

Verbeteringen:
- Breid de `focus-visible`-styling uit naar de gehele nieuwskaart wanneer een willekeurig element binnenin focus krijgt.
- Verwijder de standaard link‑omlijning binnen de kaart en gebruik één uniforme omlijning op kaartniveau voor focus.
- Restyle de 'Read more'-link tot een gecentreerd element met `max-content` en aangepaste ruimtes voor een overzichtelijkere lay-out.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the NewsCard component’s focus and visual styling for better accessibility and readability.

Enhancements:
- Expand focus-visible styling to the entire news card when any inner element is focused.
- Remove the default link outline within the card and rely on a unified card-level focus outline.
- Restyle the 'Read more' link to be a centered, max-content element with adjusted spacing for a cleaner layout.

</details>