### PR TITLE
315 feature change news component section title

### DIFF
--- a/src/lib/components/NewsComponent/NewsComponent.svelte
+++ b/src/lib/components/NewsComponent/NewsComponent.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <section>
-	<h2 class="section_title news_section_title">News, blogs & events</h2>
+	<h2 class="section_title news_section_title">Mission Updates</h2>
 	<ul class="news-grid">
 		{#each newsCards as newscard}
 			<li class="news-card">


### PR DESCRIPTION
## What does this change?

Resolves issue #315. Changes the title of the NewsComponent to 'Mission Updates' as it should be according to the website document provided by the client.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

Very minor change, didn't test.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

<img width="622" height="537" alt="image" src="https://github.com/user-attachments/assets/fd8a7ac0-ef27-43de-a9c2-d146f8507e0f" />

## How to review
- Click 'approve changes' 😊
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Samenvatting door Sourcery

Verbeteringen:
- De kop van de nieuwssectie hernoemen van "News, blogs & events" naar "Mission Updates" om deze in lijn te brengen met de tekst van de klant.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Rename the News section heading from "News, blogs & events" to "Mission Updates" to align with client copy.

</details>