### PR TITLE
329 bug pages hard to use on ultrawide monitors

### DIFF
--- a/src/lib/assets/styles/general.css
+++ b/src/lib/assets/styles/general.css
@@ -231,7 +231,7 @@ h6 {
 	line-height: clamp(1.625rem, 1.5vw + 1rem, 2rem);
 }
 
-.container-generic {
+.content-container {
 	width: 100%;
 	max-width: var(--content-width);
 	margin-inline: auto;

--- a/src/lib/assets/styles/general.css
+++ b/src/lib/assets/styles/general.css
@@ -138,7 +138,8 @@ main {
 	}
 
 	> * {
-		padding: 0 1.5rem;
+		padding-block: 0;
+		padding-inline: clamp(1rem, 5vw, 3.5rem);
 		/* Bleed out of the grid (this is just for the background colors */
 		margin-inline: -1.5rem;
 		grid-column: 1 / -1;

--- a/src/lib/assets/styles/general.css
+++ b/src/lib/assets/styles/general.css
@@ -228,6 +228,13 @@ h6 {
 	line-height: clamp(1.625rem, 1.5vw + 1rem, 2rem);
 }
 
+.container-generic {
+	width: 100%;
+	max-width: 1200px;
+	margin-inline: auto;
+	margin-block: 0;
+}
+
 a:focus-visible {
 	outline: var(--default-focus);
 }

--- a/src/lib/assets/styles/general.css
+++ b/src/lib/assets/styles/general.css
@@ -103,6 +103,9 @@ body {
 	/* Focus outline */
 	--default-focus: 0.125rem dashed var(--cleanroom-140);
 
+	/* Sizing */
+	--content-width: 1400px;
+
 	/* Styling */
 	background: var(--space-100);
 	color: var(--white);
@@ -230,7 +233,7 @@ h6 {
 
 .container-generic {
 	width: 100%;
-	max-width: 1200px;
+	max-width: var(--content-width);
 	margin-inline: auto;
 	margin-block: 0;
 }

--- a/src/lib/components/molecules/AssignmentCards.svelte
+++ b/src/lib/components/molecules/AssignmentCards.svelte
@@ -2,7 +2,7 @@
 	const { assignments } = $props()
 </script>
 
-<div class="container-generic">
+<div class="content-container">
 	<header class="assignments-header">
 		<h2 class="subtitle">Find a suitable Assignment</h2>
 		<p class="heading">
@@ -30,7 +30,7 @@
 </div>
 
 <style>
-	.container-generic {
+	.content-container {
 		padding: 0;
 	}
 

--- a/src/lib/components/molecules/AssignmentCards.svelte
+++ b/src/lib/components/molecules/AssignmentCards.svelte
@@ -2,30 +2,32 @@
 	const { assignments } = $props()
 </script>
 
-<header class="assignments-header">
-	<h2 class="subtitle">Find a suitable Assignment</h2>
-	<p class="heading">
-		Within the NEBULA Xplorer project there are
-		<span>{assignments.length}</span> assignments available.
-	</p>
-</header>
+<div class="container-generic">
+	<header class="assignments-header">
+		<h2 class="subtitle">Find a suitable Assignment</h2>
+		<p class="heading">
+			Within the NEBULA Xplorer project there are
+			<span>{assignments.length}</span> assignments available.
+		</p>
+	</header>
 
-<ul class="assignments-container">
-	{#each assignments as assignment}
-		<li class="assignment-card">
-			<a href="#">
-				<section class="assignment-content">
-					<h2 class="assignment-title">{assignment.title}</h2>
-					<div>
-						<p>{assignment.study_program}</p>
-						<p>{assignment.location}</p>
-					</div>
-				</section>
-				<p class="apply-button supporting">Apply</p>
-			</a>
-		</li>
-	{/each}
-</ul>
+	<ul class="assignments-container">
+		{#each assignments as assignment}
+			<li class="assignment-card">
+				<a href="#">
+					<section class="assignment-content">
+						<h2 class="assignment-title">{assignment.title}</h2>
+						<div>
+							<p>{assignment.study_program}</p>
+							<p>{assignment.location}</p>
+						</div>
+					</section>
+					<p class="apply-button supporting">Apply</p>
+				</a>
+			</li>
+		{/each}
+	</ul>
+</div>
 
 <style>
 	.assignments-header {
@@ -41,7 +43,7 @@
 	}
 
 	.assignments-container {
-		display: inherit;
+		display: grid;
 		grid-template-columns: subgrid;
 		gap: inherit;
 		margin-bottom: 4rem;

--- a/src/lib/components/molecules/AssignmentCards.svelte
+++ b/src/lib/components/molecules/AssignmentCards.svelte
@@ -30,6 +30,10 @@
 </div>
 
 <style>
+	.container-generic {
+		padding: 0;
+	}
+
 	.assignments-header {
 		margin-bottom: 2.5rem;
 
@@ -44,23 +48,13 @@
 
 	.assignments-container {
 		display: grid;
-		grid-template-columns: subgrid;
-		gap: inherit;
+		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+		gap: 1.25rem;
 		margin-bottom: 4rem;
 
 		.assignment-card {
 			list-style: none;
 			background: var(--space-100-low-opacity);
-
-			grid-column: 1 / -1;
-
-			@media (min-width: 32rem) {
-				grid-column: span 2;
-			}
-
-			@media (min-width: 56.25rem) {
-				grid-column: span 3;
-			}
 
 			a {
 				display: flex;

--- a/src/lib/components/molecules/AssignmentCards.svelte
+++ b/src/lib/components/molecules/AssignmentCards.svelte
@@ -48,7 +48,7 @@
 
 	.assignments-container {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr));
 		gap: 1.25rem;
 		margin-bottom: 4rem;
 

--- a/src/lib/components/molecules/Breadcrumb.svelte
+++ b/src/lib/components/molecules/Breadcrumb.svelte
@@ -36,7 +36,7 @@
 		gap: 0.75rem;
 		align-items: center;
 		width: 100%;
-		max-width: 1200px;
+		max-width: var(--content-width);
 		margin-inline: auto;
 		padding: 0;
 

--- a/src/lib/components/molecules/Breadcrumb.svelte
+++ b/src/lib/components/molecules/Breadcrumb.svelte
@@ -10,27 +10,25 @@
 	const { contrast = 'white-on-space' } = $props()
 </script>
 
-<div class="container-generic">
-	<nav class={`breadcrumb-path ${contrast}`}>
-		<a href="/" class="crumb subheading">home</a>
-		{#each pathSegments as segment, index}
-			<span class="arrow">
-				<Arrow />
+<nav class={`breadcrumb-path ${contrast}`}>
+	<a href="/" class="crumb subheading">home</a>
+	{#each pathSegments as segment, index}
+		<span class="arrow">
+			<Arrow />
+		</span>
+		{#if index + 1 < pathSegments.length}
+			<a
+				href={'/' + pathSegments.slice(0, index + 1).join('/')}
+				class="crumb subheading">
+				{sanitizeString(segment)}
+			</a>
+		{:else}
+			<span class="caption">
+				{sanitizeString(segment)}
 			</span>
-			{#if index + 1 < pathSegments.length}
-				<a
-					href={'/' + pathSegments.slice(0, index + 1).join('/')}
-					class="crumb subheading">
-					{sanitizeString(segment)}
-				</a>
-			{:else}
-				<span class="caption">
-					{sanitizeString(segment)}
-				</span>
-			{/if}
-		{/each}
-	</nav>
-</div>
+		{/if}
+	{/each}
+</nav>
 
 <style>
 	nav.breadcrumb-path {
@@ -38,6 +36,9 @@
 		gap: 0.75rem;
 		align-items: center;
 		width: 100%;
+		max-width: 1200px;
+		margin-inline: auto;
+		padding: 0;
 
 		/* color schemes */
 

--- a/src/lib/components/molecules/Breadcrumb.svelte
+++ b/src/lib/components/molecules/Breadcrumb.svelte
@@ -10,31 +10,34 @@
 	const { contrast = 'white-on-space' } = $props()
 </script>
 
-<nav class={`breadcrumb-path ${contrast}`}>
-	<a href="/" class="crumb subheading">home</a>
-	{#each pathSegments as segment, index}
-		<span class="arrow">
-			<Arrow />
-		</span>
-		{#if index + 1 < pathSegments.length}
-			<a
-				href={'/' + pathSegments.slice(0, index + 1).join('/')}
-				class="crumb subheading">
-				{sanitizeString(segment)}
-			</a>
-		{:else}
-			<span class="caption">
-				{sanitizeString(segment)}
+<div class="container-generic">
+	<nav class={`breadcrumb-path ${contrast}`}>
+		<a href="/" class="crumb subheading">home</a>
+		{#each pathSegments as segment, index}
+			<span class="arrow">
+				<Arrow />
 			</span>
-		{/if}
-	{/each}
-</nav>
+			{#if index + 1 < pathSegments.length}
+				<a
+					href={'/' + pathSegments.slice(0, index + 1).join('/')}
+					class="crumb subheading">
+					{sanitizeString(segment)}
+				</a>
+			{:else}
+				<span class="caption">
+					{sanitizeString(segment)}
+				</span>
+			{/if}
+		{/each}
+	</nav>
+</div>
 
 <style>
 	nav.breadcrumb-path {
 		display: inline-flex;
 		gap: 0.75rem;
 		align-items: center;
+		width: 100%;
 
 		/* color schemes */
 
@@ -79,10 +82,6 @@
 		a:hover {
 			text-decoration: underline;
 			text-underline-offset: 0.125rem;
-		}
-
-		@media (min-width: 56.25rem) {
-			padding-left: 4rem;
 		}
 	}
 </style>

--- a/src/lib/components/molecules/FooterLocations.svelte
+++ b/src/lib/components/molecules/FooterLocations.svelte
@@ -77,6 +77,7 @@
 			enhanced\:img {
 				width: 100%;
 				height: auto;
+				max-height: 500px;
 				display: block;
 				object-fit: cover;
 			}

--- a/src/lib/components/organisms/Hero.svelte
+++ b/src/lib/components/organisms/Hero.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <section class="hero">
-	<div class="container-generic">
+	<div class="content-container">
 		{#if paragraph}
 			<p class="subheading">{paragraph}</p>
 		{/if}

--- a/src/lib/components/organisms/Hero.svelte
+++ b/src/lib/components/organisms/Hero.svelte
@@ -18,25 +18,25 @@
 </script>
 
 <section class="hero">
-	{#if paragraph}
-		<p class="subheading">{paragraph}</p>
-	{/if}
-
-	{#if background.file}
-		<enhanced:img
-			src={background.file}
-			alt={background.alt}
-			class="hero-bg"
-			sizes="100vw"
-			fetchpriority="high" />
-	{/if}
-
-	{#if sronIcon}
-		<img src={sronIcon} alt="Logo of SRON Academy" class="hero-logo" />
-	{/if}
-	<h1 class="title" style={titleColor && `color: ${titleColor}`}>
-		{pageTitle}
-	</h1>
+	<div class="container-generic">
+		{#if paragraph}
+			<p class="subheading">{paragraph}</p>
+		{/if}
+		{#if background.file}
+			<enhanced:img
+				src={background.file}
+				alt={background.alt}
+				class="hero-bg"
+				sizes="100vw"
+				fetchpriority="high" />
+		{/if}
+		{#if sronIcon}
+			<img src={sronIcon} alt="Logo of SRON Academy" class="hero-logo" />
+		{/if}
+		<h1 class="title" style={titleColor && `color: ${titleColor}`}>
+			{pageTitle}
+		</h1>
+	</div>
 </section>
 
 <style>

--- a/src/lib/components/organisms/NewsComponent.svelte
+++ b/src/lib/components/organisms/NewsComponent.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <section>
-	<div class="container-generic">
+	<div class="content-container">
 		<h2 class="section_title news_section_title">Mission Updates</h2>
 		<ul class="news-grid">
 			{#each newsCards as newscard}

--- a/src/lib/components/organisms/NewsComponent.svelte
+++ b/src/lib/components/organisms/NewsComponent.svelte
@@ -5,23 +5,27 @@
 </script>
 
 <section>
-	<h2 class="section_title news_section_title">Mission Updates</h2>
-	<ul class="news-grid">
-		{#each newsCards as newscard}
-			<li class="news-card">
-				<img
-					src={newscard.image
-						? `https://fdnd-agency.directus.app/assets/${newscard.image}`
-						: defaultImage}
-					alt=""
-					height="240"
-					width="240" />
-				<h3><a href={`/news/${newscard.id}`}>{newscard.title}</a></h3>
-				<p>{newscard.type}</p>
-			</li>
-		{/each}
-	</ul>
-	<a href="/news" class="paragraph link-readmore">Read More</a>
+	<div class="container-generic">
+		<h2 class="section_title news_section_title">Mission Updates</h2>
+		<ul class="news-grid">
+			{#each newsCards as newscard}
+				<li class="news-card">
+					<img
+						src={newscard.image
+							? `https://fdnd-agency.directus.app/assets/${newscard.image}`
+							: defaultImage}
+						alt=""
+						height="240"
+						width="240" />
+					<h3>
+						<a href={`/news/${newscard.id}`}>{newscard.title}</a>
+					</h3>
+					<p>{newscard.type}</p>
+				</li>
+			{/each}
+		</ul>
+		<a href="/news" class="paragraph link-readmore">Read More</a>
+	</div>
 </section>
 
 <style>

--- a/src/lib/components/organisms/PillarsComponent.svelte
+++ b/src/lib/components/organisms/PillarsComponent.svelte
@@ -47,7 +47,7 @@
 </script>
 
 <section>
-	<div class="container-generic">
+	<div class="content-container">
 		<h2 class="section_title">Pillars</h2>
 		<!-- TODO: make the things inside this #each loop into a seperate component partial -->
 		<ul>

--- a/src/lib/components/organisms/PillarsComponent.svelte
+++ b/src/lib/components/organisms/PillarsComponent.svelte
@@ -47,17 +47,18 @@
 </script>
 
 <section>
-	<h2 class="section_title">Pillars</h2>
-	<!-- TODO: make the things inside this #each loop into a seperate component partial -->
-	<ul>
-		{#each dummydata as data}
-			<li class="pillar">
-				<img src={data.image.src} alt={data.image.alt} />
-
-				<a href={data.link}> {data.title}</a>
-			</li>
-		{/each}
-	</ul>
+	<div class="container-generic">
+		<h2 class="section_title">Pillars</h2>
+		<!-- TODO: make the things inside this #each loop into a seperate component partial -->
+		<ul>
+			{#each dummydata as data}
+				<li class="pillar">
+					<img src={data.image.src} alt={data.image.alt} />
+					<a href={data.link}> {data.title}</a>
+				</li>
+			{/each}
+		</ul>
+	</div>
 </section>
 
 <style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,25 +24,28 @@
 <News newsCards={data.newsItems} />
 
 <section class="section-paragraph-picture">
-	<h2 class="section_title">Over Nebula Xplorer</h2>
-	<p class="paragraph">
-		NEBULA – Xplorer staat voor “Netherlands Educational Satellite for
-		Exploration of Binary-Linked Astrophysics – X-ray Observer”. Ongeveer
-		vierhonderd studenten helpen SRON, veertien Nederlandse
-		onderwijsinstellingen en vele industriële partners om deze ruimtemissie
-		te ontwikkelen van begin tot eind, onder leiding van wetenschappers en
-		ingenieurs. De missie heeft twee doelen. Het wetenschappelijke doel is
-		beter begrijpen hoe een zwart gat materiaal afsnoept van een ster die er
-		omheen draait. Het educatieve doel is dat studenten van Nederlandse
-		onderwijsinstellingen van binnenuit meemaken hoe je een ruimtemissie van
-		begin tot eind opbouwt. SRON heeft de leiding over NEBULA – Xplorer,
-		waarmee het bijdraagt aan een nieuwe generatie wetenschappers,
-		ontwerpers en technici voor het Nederlandse ruimteonderzoek.
-	</p>
-	<enhanced:img
-		src={nebulaSatelliteEnhanced}
-		alt="The Nebula Xplorer Satellite"
-		sizes="(min-width:500px) 900px, (min-width:300px) 450px" />
+	<div class="container-generic">
+		<h2 class="section_title">Over Nebula Xplorer</h2>
+		<p class="paragraph">
+			NEBULA – Xplorer staat voor “Netherlands Educational Satellite for
+			Exploration of Binary-Linked Astrophysics – X-ray Observer”.
+			Ongeveer vierhonderd studenten helpen SRON, veertien Nederlandse
+			onderwijsinstellingen en vele industriële partners om deze
+			ruimtemissie te ontwikkelen van begin tot eind, onder leiding van
+			wetenschappers en ingenieurs. De missie heeft twee doelen. Het
+			wetenschappelijke doel is beter begrijpen hoe een zwart gat
+			materiaal afsnoept van een ster die er omheen draait. Het educatieve
+			doel is dat studenten van Nederlandse onderwijsinstellingen van
+			binnenuit meemaken hoe je een ruimtemissie van begin tot eind
+			opbouwt. SRON heeft de leiding over NEBULA – Xplorer, waarmee het
+			bijdraagt aan een nieuwe generatie wetenschappers, ontwerpers en
+			technici voor het Nederlandse ruimteonderzoek.
+		</p>
+		<enhanced:img
+			src={nebulaSatelliteEnhanced}
+			alt="The Nebula Xplorer Satellite"
+			sizes="(min-width:500px) 900px, (min-width:300px) 450px" />
+	</div>
 </section>
 
 <PillarsComponent />
@@ -50,15 +53,10 @@
 <MailingListSignup />
 
 <style>
-	.section-paragraph-picture {
+	.section-paragraph-picture div {
 		display: grid;
 		gap: 2rem;
 		padding-block: 3rem;
-		padding-inline: clamp(
-			1rem,
-			5vw,
-			3.5rem
-		); /* TODO: make this the standard padding for sections in general.css */
 
 		@media (min-width: 1000px) {
 			grid-template-columns: 2fr 1fr;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,7 +24,7 @@
 <News newsCards={data.newsItems} />
 
 <section class="section-paragraph-picture">
-	<div class="container-generic">
+	<div class="content-container">
 		<h2 class="section_title">Over Nebula Xplorer</h2>
 		<p class="paragraph">
 			NEBULA – Xplorer staat voor “Netherlands Educational Satellite for

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -337,8 +337,8 @@
 			padding-bottom: 2rem;
 			font-weight: 500;
 
-			@media (min-width: 56.25rem) {
-				> *:not(enhanced\:img, img, picture) {
+			> *:not(enhanced\:img, img, picture) {
+				@media (min-width: 36.25rem) {
 					grid-column: 6 / -1;
 					padding-left: 1.5rem;
 					justify-self: flex-end;
@@ -346,6 +346,9 @@
 			}
 
 			:global(picture) {
+				grid-column: 1 / 6;
+				grid-row: 1 / 2;
+
 				@media (min-width: 56.25rem) {
 					grid-column: 1 / 6;
 				}

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -341,6 +341,7 @@
 				> *:not(enhanced\:img, img, picture) {
 					grid-column: 6 / -1;
 					padding-left: 1.5rem;
+					justify-self: flex-end;
 				}
 			}
 

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -26,16 +26,19 @@
 <Breadcrumb />
 
 <!-- FIRST PARAGRAPH + IMG BLOCK -->
+<div class="container-generic">
+	<hgroup class="text-title">
+		<h2 class="subtitle">
+			What are we <span class="orange">up</span> to?
+		</h2>
+		<p class="heading">What our current project entails</p>
+	</hgroup>
+</div>
 
 <section class="paragraph-block">
-	<div class="text-title">
-		<h2 class="subtitle">What are we <span class="orange">up</span> to?</h2>
-		<p class="heading">What our current project entails</p>
-	</div>
-
-	<section class="text-content">
-		<article>
-			<h4 class="orange heading">Dense matter and compact objects</h4>
+	<div class="container-generic">
+		<section class="text-content">
+			<h3 class="orange heading">Dense matter and compact objects</h3>
 			<p>
 				NEBULA-Xplorer will investigate compact objects such as neutron
 				stars and black hole X-ray binaries within our Milky Way. By
@@ -48,7 +51,6 @@
 				systems, where light is most affected by the gravity of compact
 				objects and the magnetic environment of neutron stars.
 			</p>
-
 			<p>
 				By observing black holes in this energy range, we can also
 				measure the spin of black holes by observing the relativistic
@@ -59,21 +61,21 @@
 				implications for stellar evolution in binary systems which are
 				estimated to make up to 85% of star systems in our universe.
 			</p>
-		</article>
-	</section>
-	<enhanced:img src={blackholeImage} alt="Black Hole" />
+		</section>
+		<enhanced:img src={blackholeImage} alt="Black Hole" />
+	</div>
 </section>
 
 <!-- SECOND IMG + PARAGRAPH BLOCK -->
 
 <section class="paragraph-block paragraph-block-alt">
-	<enhanced:img
-		class="paragraph-img-left"
-		src={blackholeImage}
-		alt="Black Hole" />
-	<section class="text-content">
-		<article>
-			<h4 class="orange heading">Multi-messenger physics</h4>
+	<div class="container-generic">
+		<enhanced:img
+			class="paragraph-img-left"
+			src={blackholeImage}
+			alt="Black Hole" />
+		<section class="text-content">
+			<h3 class="orange heading">Multi-messenger physics</h3>
 			<p>
 				NEBULA-Xplorer frames the multi-wavelength campaigns required to
 				understand jet and accretion physics at the forefront of its
@@ -83,7 +85,6 @@
 				ability to maintain as close to continuous observations of
 				targets as possible.
 			</p>
-
 			<p>
 				During longer observations, NEBULA-Xplorer will transmit timing
 				information key to understanding when ballistic jet ejections
@@ -95,16 +96,16 @@
 				understand how activity in the outer accretion disk of these
 				systems propagates into the inner-most regions.
 			</p>
-		</article>
-	</section>
+		</section>
+	</div>
 </section>
 
 <!-- THIRD PARAGRAPH + IMG BLOCK -->
 
 <section class="paragraph-block">
-	<section class="text-content">
-		<article>
-			<h4 class="orange heading">Time-domain Astrophysics</h4>
+	<div class="container-generic">
+		<section class="text-content">
+			<h3 class="orange heading">Time-domain Astrophysics</h3>
 			<p>
 				As a non-imaging X-ray timing observatory, NEBULA-Xplorer’s core
 				science focuses on interpreting the variability of emission from
@@ -117,7 +118,6 @@
 				disk and companion star in these systems obscuring the central
 				accretion engine.
 			</p>
-
 			<p>
 				Frequently, changes in variability are affected by multiple
 				phenomena in the system that evolve on different time scales,
@@ -128,7 +128,6 @@
 				will allow us to understand the short-term variability of
 				emission and how that changes on timescales of days to weeks.
 			</p>
-
 			<p>
 				NEBULA-Xplorer’s moderate energy resolution and high timing
 				resolution will also allow us to perform spectral-timing
@@ -139,9 +138,9 @@
 				distances between different parts of the system through modeling
 				of light travel time within the system.
 			</p>
-		</article>
-	</section>
-	<enhanced:img src={blackholeImage} alt="Black Hole" />
+		</section>
+		<enhanced:img src={blackholeImage} alt="Black Hole" />
+	</div>
 </section>
 
 <!-- STEPS BLOCK -->
@@ -274,11 +273,9 @@
 </figure>
 
 <style>
-	/* FIRST PARAGRAPH BLOCK */
-
-	.paragraph-block {
+	.paragraph-block div {
 		display: grid;
-		grid-template-columns: subgrid;
+		grid-template-columns: repeat(12, 1fr);
 		gap: inherit;
 		row-gap: unset;
 		margin-bottom: 1rem;
@@ -288,16 +285,17 @@
 			max-width: 43.75rem;
 
 			@media (min-width: 36.25rem) {
-				grid-column: 1 / 4;
+				grid-column: 1 / 8;
 				padding-right: 1.5rem;
 			}
 			@media (min-width: 56.25rem) {
 				padding-left: 2.5rem;
-				grid-column: 1 / 8;
 			}
 		}
 
-		.text-content article {
+		.text-content {
+			grid-row: 1 / 2;
+
 			* + p {
 				margin-top: 0.5rem;
 				line-height: 1.7;
@@ -313,20 +311,16 @@
 		}
 
 		:global(picture) {
-			grid-column: 4 / -1;
+			grid-column: 8 / -1;
 			height: fit-content;
 			display: none;
-
-			@media (prefers-reduced-motion: no-preference) {
-				position: sticky;
-				top: 20%;
-			}
 
 			@media (min-width: 36.25rem) {
 				display: block;
 			}
 
 			@media (min-width: 56.25rem) {
+				grid-row: 1 / 2;
 				grid-column: 8 / -1;
 			}
 
@@ -339,37 +333,37 @@
 		}
 	}
 
-	/* SECOND PARAGRAPH BLOCK */
-
 	.paragraph-block-alt {
-		padding-bottom: 2rem;
 		background-color: var(--white);
 		color: var(--space-100);
-		font-weight: 500;
 
-		@media (min-width: 56.25rem) {
-			> *:not(enhanced\:img, img, picture) {
-				grid-column: 6 / 12;
-				align-items: right;
-			}
-		}
+		div {
+			padding-bottom: 2rem;
 
-		:global(picture) {
-			grid-row: 1 / 2;
+			font-weight: 500;
 
 			@media (min-width: 56.25rem) {
-				grid-column: 1 / 6;
+				> *:not(enhanced\:img, img, picture) {
+					grid-column: 6 / 12;
+					align-items: right;
+				}
 			}
 
-			:global(enhanced\:img),
-			:global(img) {
-				display: none;
+			:global(picture) {
+				@media (min-width: 56.25rem) {
+					grid-column: 1 / 6;
+				}
 
-				@media (min-width: 36.25rem) {
-					display: block;
-					width: 100%;
-					object-fit: cover;
-					max-height: 22.8125rem;
+				:global(enhanced\:img),
+				:global(img) {
+					display: none;
+
+					@media (min-width: 36.25rem) {
+						display: block;
+						width: 100%;
+						object-fit: cover;
+						max-height: 22.8125rem;
+					}
 				}
 			}
 		}

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -28,7 +28,7 @@
 <!-- FIRST PARAGRAPH + IMG BLOCK -->
 
 <hgroup class="text-title">
-	<div class="container-generic">
+	<div class="content-container">
 		<h2 class="subtitle">
 			What are we <span class="orange">up</span> to?
 		</h2>
@@ -37,7 +37,7 @@
 </hgroup>
 
 <section class="paragraph-block">
-	<div class="container-generic">
+	<div class="content-container">
 		<section class="text-content">
 			<h3 class="orange heading">Dense matter and compact objects</h3>
 			<p>
@@ -70,7 +70,7 @@
 <!-- SECOND IMG + PARAGRAPH BLOCK -->
 
 <section class="paragraph-block paragraph-block-alt">
-	<div class="container-generic">
+	<div class="content-container">
 		<enhanced:img
 			class="paragraph-img-left"
 			src={blackholeImage}
@@ -104,7 +104,7 @@
 <!-- THIRD PARAGRAPH + IMG BLOCK -->
 
 <section class="paragraph-block">
-	<div class="container-generic">
+	<div class="content-container">
 		<section class="text-content">
 			<h3 class="orange heading">Time-domain Astrophysics</h3>
 			<p>

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -66,12 +66,12 @@
 
 <!-- SECOND IMG + PARAGRAPH BLOCK -->
 
-<section class="paragraph-block-right">
+<section class="paragraph-block paragraph-block-alt">
 	<enhanced:img
 		class="paragraph-img-left"
 		src={blackholeImage}
 		alt="Black Hole" />
-	<section class="text-content-right">
+	<section class="text-content">
 		<article>
 			<h4 class="orange heading">Multi-messenger physics</h4>
 			<p>
@@ -101,8 +101,8 @@
 
 <!-- THIRD PARAGRAPH + IMG BLOCK -->
 
-<section class="paragraph-block-3">
-	<section class="text-content-3">
+<section class="paragraph-block">
+	<section class="text-content">
 		<article>
 			<h4 class="orange heading">Time-domain Astrophysics</h4>
 			<p>
@@ -341,54 +341,21 @@
 
 	/* SECOND PARAGRAPH BLOCK */
 
-	.paragraph-block-right {
-		display: grid;
-		grid-template-columns: subgrid;
-		gap: inherit;
-		row-gap: unset;
+	.paragraph-block-alt {
 		padding-bottom: 2rem;
 		background-color: var(--white);
 		color: var(--space-100);
 		font-weight: 500;
 
-		> *:not(enhanced\:img, img, picture) {
-			grid-column: 1 / -1;
-			max-width: 43.75rem;
-
-			@media (min-width: 36.25rem) {
-				grid-column: 1 / 4;
-				padding-right: 1.5rem;
-			}
-			@media (min-width: 56.25rem) {
-				padding-left: 2.5rem;
+		@media (min-width: 56.25rem) {
+			> *:not(enhanced\:img, img, picture) {
 				grid-column: 6 / 12;
 				align-items: right;
 			}
 		}
 
-		.text-content-right article {
-			* + p {
-				margin-top: 0.5rem;
-				line-height: 1.5;
-				@media (min-width: 56.25rem) {
-					padding-left: 1.5rem;
-				}
-			}
-		}
-
-		:global(.text-content),
 		:global(picture) {
-			margin-top: 3rem;
-		}
-
-		:global(picture) {
-			grid-column: 4 / -1;
-			height: fit-content;
-			display: none;
-
-			@media (min-width: 36.25rem) {
-				display: block;
-			}
+			grid-row: 1 / 2;
 
 			@media (min-width: 56.25rem) {
 				grid-column: 1 / 6;
@@ -407,85 +374,6 @@
 			}
 		}
 	}
-
-	/* THIRD PARAGRAPH + IMG BLOCK */
-
-	.paragraph-block-3 {
-		display: grid;
-		grid-template-columns: subgrid;
-		gap: inherit;
-		row-gap: unset;
-		margin-bottom: 1rem;
-
-		> *:not(enhanced\:img, img, picture) {
-			grid-column: 1 / -1;
-			max-width: 43.75rem;
-
-			@media (min-width: 36.25rem) {
-				grid-column: 1 / 4;
-				padding-right: 1.5rem;
-			}
-			@media (min-width: 56.25rem) {
-				padding-left: 2.5rem;
-				grid-column: 1 / 8;
-			}
-		}
-
-		.text-content-3 article {
-			* + p {
-				margin-top: 0.5rem;
-				line-height: 1.5;
-				@media (min-width: 56.25rem) {
-					padding-left: 1.5rem;
-					margin-bottom: 1.5rem;
-				}
-			}
-		}
-
-		:global(.text-content),
-		:global(picture) {
-			margin-top: 3rem;
-		}
-
-		:global(picture) {
-			grid-column: 4 / -1;
-			height: fit-content;
-
-			display: none;
-
-			@media (min-width: 36.25rem) {
-				display: block;
-			}
-
-			@media (min-width: 56.25rem) {
-				grid-column: 8 / -1;
-
-				@media (prefers-reduced-motion: no-preference) {
-					position: sticky;
-					top: 30%;
-					margin-bottom: 1.5rem;
-				}
-			}
-
-			:global(enhanced\:img),
-			:global(img) {
-				width: 100%;
-				object-fit: cover;
-				max-height: 22.8125rem;
-			}
-		}
-	}
-
-	.text-content-3 article {
-		p {
-			color: var(--white);
-			font-weight: 500;
-		}
-	}
-
-	/* .article {
-    margin-bottom: 2rem;
-  } */
 
 	/* STEPS BLOCK */
 
@@ -660,19 +548,6 @@
 		box-shadow: 0 0.25rem 0.375rem rgba(0, 0, 0, 0.3);
 	}
 
-	/* GETTING INVOLVED */
-	/* 
-  .getting-involved {
-    padding-left: 1.5rem;
-    margin-bottom: 1.5rem;
-    text-align: center;
-
-    p {
-      margin-top: 1rem;
-      padding: 0 3rem 0 3rem;
-    }
-  } */
-
 	/* TESTIMONIAL BLOCK */
 
 	.testimonial-container {
@@ -770,8 +645,4 @@
 		font-weight: 500;
 		padding-top: 1.5rem;
 	}
-
-	/* article + article {
-  margin-top: 2rem;
-} */
 </style>

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -26,14 +26,15 @@
 <Breadcrumb />
 
 <!-- FIRST PARAGRAPH + IMG BLOCK -->
-<div class="container-generic">
-	<hgroup class="text-title">
+
+<hgroup class="text-title">
+	<div class="container-generic">
 		<h2 class="subtitle">
 			What are we <span class="orange">up</span> to?
 		</h2>
 		<p class="heading">What our current project entails</p>
-	</hgroup>
-</div>
+	</div>
+</hgroup>
 
 <section class="paragraph-block">
 	<div class="container-generic">
@@ -289,9 +290,6 @@
 				grid-column: 1 / 8;
 				padding-right: 1.5rem;
 			}
-			@media (min-width: 56.25rem) {
-				padding-left: 2.5rem;
-			}
 		}
 
 		.text-content {
@@ -300,9 +298,6 @@
 			* + p {
 				margin-top: 0.5rem;
 				line-height: 1.7;
-				@media (min-width: 56.25rem) {
-					padding-left: 1.5rem;
-				}
 			}
 		}
 
@@ -340,13 +335,12 @@
 
 		div {
 			padding-bottom: 2rem;
-
 			font-weight: 500;
 
 			@media (min-width: 56.25rem) {
 				> *:not(enhanced\:img, img, picture) {
-					grid-column: 6 / 12;
-					align-items: right;
+					grid-column: 6 / -1;
+					padding-left: 1.5rem;
 				}
 			}
 

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -279,6 +279,7 @@
 		gap: inherit;
 		row-gap: unset;
 		margin-bottom: 1rem;
+		align-items: center;
 
 		> *:not(enhanced\:img, img, picture) {
 			grid-column: 1 / -1;

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -301,13 +301,14 @@
 			}
 		}
 
-		:global(.text-content),
-		:global(picture) {
+		.text-content,
+		picture {
 			margin-top: 3rem;
 		}
 
-		:global(picture) {
+		picture {
 			grid-column: 8 / -1;
+			grid-row: 1 / 2;
 			height: fit-content;
 			display: none;
 
@@ -315,13 +316,8 @@
 				display: block;
 			}
 
-			@media (min-width: 56.25rem) {
-				grid-row: 1 / 2;
-				grid-column: 8 / -1;
-			}
-
-			:global(enhanced\:img),
-			:global(img) {
+			enhanced\:img,
+			img {
 				width: 100%;
 				object-fit: cover;
 				max-height: 22.8125rem;
@@ -345,16 +341,12 @@
 				}
 			}
 
-			:global(picture) {
+			picture {
 				grid-column: 1 / 6;
 				grid-row: 1 / 2;
 
-				@media (min-width: 56.25rem) {
-					grid-column: 1 / 6;
-				}
-
-				:global(enhanced\:img),
-				:global(img) {
+				enhanced\:img,
+				img {
 					display: none;
 
 					@media (min-width: 36.25rem) {


### PR DESCRIPTION
## What does this change?

Resolves issue #329. Adds a container that restrains the max width of the content, and apply this container to the whole website. This PR admittedly got a little out of hand. I ended up reworking most of the mission page just so I could apply my little max-width container.

- Adds a class to general.css called content-container meant to contain your content.
- Adds a variable to general.css called content-width that is used by the content-container, so you can control the content width in one spot
- Refactors the css on the mission page, removing subgrid. Also just generally makes it look nicer.
- Refactors the css on the assignments page to also remove subgrid
- Adds a max height to footer images so that they don't take up your entire screen height on wider screens
- Removes the sticky images on the mission page and just vertically centers them instead (#346)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

Tested on Chrome and Firefox from 300px to 3000px. Ran a lighthouse test on the mission page and found no issues with accessibility.

## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Check if everything looks nice on your device/browser
- Check if the code I refactored makes sense
- Check if the way I implemented the max-width container makes sense