### PR TITLE
369 feature assignment detail page fetch

### DIFF
--- a/src/lib/components/molecules/AssignmentCards.svelte
+++ b/src/lib/components/molecules/AssignmentCards.svelte
@@ -14,7 +14,7 @@
 	<ul class="assignments-container">
 		{#each assignments as assignment}
 			<li class="assignment-card">
-				<a href="#">
+				<a href={`/assignments/${assignment.id}`}>
 					<section class="assignment-content">
 						<h2 class="assignment-title">{assignment.title}</h2>
 						<div>

--- a/src/routes/assignments/[slug]/+page.server.js
+++ b/src/routes/assignments/[slug]/+page.server.js
@@ -5,5 +5,5 @@ export async function load({ url, params }) {
 		`${DIRECTUS_VACANCIES}/${params.slug}`
 	).then((response) => response.json())
 
-	return { assignment: vacanciesResponse.data ?? [] }
+	return { assignment: vacanciesResponse.data }
 }

--- a/src/routes/assignments/[slug]/+page.server.js
+++ b/src/routes/assignments/[slug]/+page.server.js
@@ -1,0 +1,9 @@
+import { DIRECTUS_VACANCIES } from '$env/static/private'
+
+export async function load({ url, params }) {
+	const vacanciesResponse = await fetch(
+		`${DIRECTUS_VACANCIES}/${params.slug}`
+	).then((response) => response.json())
+
+	return { assignment: vacanciesResponse.data ?? [] }
+}

--- a/src/routes/assignments/[slug]/+page.svelte
+++ b/src/routes/assignments/[slug]/+page.svelte
@@ -1,7 +1,6 @@
 <script>
 	import { Breadcrumb, Hero } from '$lib'
 	let { data } = $props()
-	console.log(data)
 </script>
 
 <Hero pageTitle="Assignment" />

--- a/src/routes/assignments/[slug]/+page.svelte
+++ b/src/routes/assignments/[slug]/+page.svelte
@@ -7,7 +7,7 @@
 
 <Breadcrumb />
 
-{#if data.assignment.length > 0}
+{#if data.assignment}
 	<h2>{data.assignment.title}</h2>
 	<p>{data.assignment.location}</p>
 	<p>{data.assignment.organisation}</p>

--- a/src/routes/assignments/[slug]/+page.svelte
+++ b/src/routes/assignments/[slug]/+page.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { Breadcrumb, Hero } from '$lib'
+	let { data } = $props()
+	console.log(data)
+</script>
+
+<Hero pageTitle="Assignment" />
+
+<Breadcrumb />
+
+{#if data.assignment.length > 0}
+	<h2>{data.assignment.title}</h2>
+	<p>{data.assignment.location}</p>
+	<p>{data.assignment.organisation}</p>
+
+	<p>{data.assignment.summary}</p>
+	<p>{data.assignment.description}</p>
+{:else}
+	<p>Assignment not found.</p>
+{/if}


### PR DESCRIPTION
## What does this change?

Resolves issue #369.
- Adds a fetch that fetches a specific assignment, with a basic fallback
- Updates the hrefs in AssignmentCards component to link to the detail page
- Display basic data in detail page (to be styled in #370), with a basic fallback

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

There is little to no front-end as of now.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Check if it works on your device/browser
- Check if the fallback works (try a random url)
- Check if the code looks good and whether anything can be improved
