### PR TITLE
Feat: make cool hover effect work with focus as well #266

### DIFF
--- a/src/lib/components/molecules/FooterNav.svelte
+++ b/src/lib/components/molecules/FooterNav.svelte
@@ -127,29 +127,30 @@
 		li {
 			display: contents;
 
-			&:is(:nth-child(5n + 5), :last-child) {
-				color: var(--cleanroom-30);
-			}
-
-			&:hover {
+			&:hover,
+			&:focus-within {
 				color: var(--cleanroom-60);
 			}
 
 			@supports selector(a:has(b)) {
 				/* Nice inspo https://tobiasahlin.com/blog/previous-sibling-css-has/ */
 				&:hover + li,
-				&:has(+ li:hover) {
+				&:focus-within + li,
+				&:has(+ li:hover),
+				&:has(+ li:focus-within) {
 					color: var(--cleanroom-60);
 				}
 			}
 		}
+
 		a {
 			display: inline;
 			width: fit-content;
 
 			transition: color 0.3s ease;
 
-			&:hover {
+			&:hover,
+			&:focus {
 				color: var(--cleanroom-100);
 			}
 


### PR DESCRIPTION
## What does this change?

Resolves issue #266. Makes the cool hover effect work with focus as well. Also remove the orange hue from assignments and privacy because no one knew why it was there.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

Tested with keyboard navigation, of course.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

<img width="868" height="81" alt="image" src="https://github.com/user-attachments/assets/c9229d26-d676-455d-854c-5756ab179287" />

## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Check if it works on your device/browser