### PR TITLE
378 feature assignment page adjustments

### DIFF
--- a/src/lib/components/molecules/AssignmentCards.svelte
+++ b/src/lib/components/molecules/AssignmentCards.svelte
@@ -19,7 +19,7 @@
 				<li class="assignment-card">
 					<a href={`/assignments/${assignment.id}`}>
 						<section class="assignment-content">
-							<h2 class="assignment-title">{assignment.title}</h2>
+							<h3 class="assignment-title">{assignment.title}</h3>
 							<div>
 								<p>{assignment.study_program}</p>
 								<p>{assignment.location}</p>

--- a/src/lib/components/molecules/AssignmentCards.svelte
+++ b/src/lib/components/molecules/AssignmentCards.svelte
@@ -9,7 +9,7 @@
 				Find a <span class="orange">suitable</span> assignment
 			</h2>
 			<p class="heading">
-				Within the NEBULA Xplorer project there are
+				Within the NEBULA-Xplorer project there are
 				<span>{assignments.length}</span> assignments available.
 			</p>
 		</header>

--- a/src/lib/components/molecules/AssignmentCards.svelte
+++ b/src/lib/components/molecules/AssignmentCards.svelte
@@ -10,23 +10,23 @@
 			</h2>
 			<p class="heading">
 				Within the NEBULA-Xplorer project there are
-				<span>{assignments.length}</span> assignments available.
+				<span class="orange">{assignments.length}</span> assignments available.
 			</p>
 		</header>
 
 		<ul class="assignments-container">
 			{#each assignments as assignment}
 				<li class="assignment-card">
-					<a href={`/assignments/${assignment.id}`}>
-						<section class="assignment-content">
+					<section class="assignment-content">
+						<a href={`/assignments/${assignment.id}`}>
 							<h3 class="assignment-title">{assignment.title}</h3>
-							<div>
-								<p>{assignment.study_program}</p>
-								<p>{assignment.location}</p>
-							</div>
-						</section>
-						<p class="apply-button supporting">Apply</p>
-					</a>
+						</a>
+						<div>
+							<p>{assignment.study_program}</p>
+							<p>{assignment.location}</p>
+						</div>
+					</section>
+					<p class="apply-button supporting">Apply</p>
 				</li>
 			{/each}
 		</ul>
@@ -40,10 +40,6 @@
 		h2 {
 			margin-bottom: 0.5rem;
 		}
-
-		p span {
-			color: var(--cleanroom-140);
-		}
 	}
 
 	.assignments-container {
@@ -51,68 +47,78 @@
 		grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr));
 		gap: 1.25rem;
 		margin-bottom: 4rem;
+	}
 
-		.assignment-card {
-			list-style: none;
-			background: var(--space-100-low-opacity);
+	.assignment-card {
+		list-style: none;
+		background: var(--space-100-low-opacity);
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		height: 100%;
+		min-height: 11.25rem;
 
-			a {
-				display: flex;
-				flex-direction: column;
-				justify-content: space-between;
-				height: 100%;
-				min-height: 11.25rem;
-
-				.assignment-content {
-					padding: 1rem;
-					display: inherit;
-					flex-direction: inherit;
-					justify-content: inherit;
-					height: 100%;
-					color: var(--cleanroom-10);
-
-					.assignment-title {
-						color: var(--cleanroom-140);
-						margin-bottom: 1rem;
-					}
-
-					div {
-						display: inherit;
-						flex-direction: inherit;
-						gap: 0.25rem;
-						p {
-							text-transform: capitalize;
-
-							&:last-child {
-								margin-bottom: 0.5rem;
-							}
-						}
-					}
-
-					/* For the next iteration I recommend changing the capitalization of the values in the fields on Directus instead of capitalizing them with CSS */
-				}
-
-				&:hover {
-					.apply-button {
-						background: var(--ultra-100);
-						color: var(--cleanroom-60);
-					}
-				}
-			}
+		&:focus-within {
+			outline: var(--default-focus);
 		}
 
-		.apply-button {
-			display: inline-block;
-			text-align: center;
-			padding: 1rem;
-			width: 100%;
-			color: var(--space-100);
-			background: var(--cleanroom-100);
-			text-transform: uppercase;
+		&:hover .apply-button,
+		&:focus-within .apply-button {
+			background: var(--ultra-100);
+			color: var(--cleanroom-60);
 		}
 	}
 
+	.assignment-content {
+		padding: 1rem;
+		display: inherit;
+		flex-direction: inherit;
+		justify-content: inherit;
+		height: 100%;
+		color: var(--cleanroom-10);
+		position: relative;
+
+		div {
+			display: inherit;
+			flex-direction: inherit;
+			gap: 0.25rem;
+			padding-block-end: 0.5rem;
+			text-transform: capitalize;
+		}
+
+		/* For the next iteration I recommend changing the capitalization of the values in the fields on Directus instead of capitalizing them with CSS */
+
+		a {
+			outline: none;
+		}
+
+		a::after {
+			content: '';
+			top: 0;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			position: absolute;
+		}
+	}
+
+	.assignment-title {
+		font-size: 1.5rem;
+		color: var(--cleanroom-140);
+		margin-bottom: 1rem;
+	}
+
+	.apply-button {
+		display: inline-block;
+		text-align: center;
+		padding: 1rem;
+		width: 100%;
+		color: var(--space-100);
+		background: var(--cleanroom-100);
+		text-transform: uppercase;
+	}
+
 	.orange {
-		color: var(--cleanroom-100);
+		color: var(--cleanroom-140);
 	}
 </style>

--- a/src/lib/components/molecules/AssignmentCards.svelte
+++ b/src/lib/components/molecules/AssignmentCards.svelte
@@ -4,7 +4,9 @@
 
 <div class="content-container">
 	<header class="assignments-header">
-		<h2 class="subtitle">Find a suitable Assignment</h2>
+		<h2 class="subtitle">
+			Find a <span class="orange">suitable</span> assignment
+		</h2>
 		<p class="heading">
 			Within the NEBULA Xplorer project there are
 			<span>{assignments.length}</span> assignments available.
@@ -110,5 +112,9 @@
 			background: var(--cleanroom-100);
 			text-transform: uppercase;
 		}
+	}
+
+	.orange {
+		color: var(--cleanroom-100);
 	}
 </style>

--- a/src/lib/components/molecules/AssignmentCards.svelte
+++ b/src/lib/components/molecules/AssignmentCards.svelte
@@ -2,40 +2,38 @@
 	const { assignments } = $props()
 </script>
 
-<div class="content-container">
-	<header class="assignments-header">
-		<h2 class="subtitle">
-			Find a <span class="orange">suitable</span> assignment
-		</h2>
-		<p class="heading">
-			Within the NEBULA Xplorer project there are
-			<span>{assignments.length}</span> assignments available.
-		</p>
-	</header>
+<section>
+	<div class="content-container">
+		<header class="assignments-header">
+			<h2 class="subtitle">
+				Find a <span class="orange">suitable</span> assignment
+			</h2>
+			<p class="heading">
+				Within the NEBULA Xplorer project there are
+				<span>{assignments.length}</span> assignments available.
+			</p>
+		</header>
 
-	<ul class="assignments-container">
-		{#each assignments as assignment}
-			<li class="assignment-card">
-				<a href={`/assignments/${assignment.id}`}>
-					<section class="assignment-content">
-						<h2 class="assignment-title">{assignment.title}</h2>
-						<div>
-							<p>{assignment.study_program}</p>
-							<p>{assignment.location}</p>
-						</div>
-					</section>
-					<p class="apply-button supporting">Apply</p>
-				</a>
-			</li>
-		{/each}
-	</ul>
-</div>
+		<ul class="assignments-container">
+			{#each assignments as assignment}
+				<li class="assignment-card">
+					<a href={`/assignments/${assignment.id}`}>
+						<section class="assignment-content">
+							<h2 class="assignment-title">{assignment.title}</h2>
+							<div>
+								<p>{assignment.study_program}</p>
+								<p>{assignment.location}</p>
+							</div>
+						</section>
+						<p class="apply-button supporting">Apply</p>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</div>
+</section>
 
 <style>
-	.content-container {
-		padding: 0;
-	}
-
 	.assignments-header {
 		margin-bottom: 2.5rem;
 


### PR DESCRIPTION
## What does this change?

Resolves issue #378. Implements some adjustments to the assignments page that the client requested, and fixes a slight bug with the content-width container. 
Edit: I have also refactored the HTML and CSS because I noticed some things that were bothering me. I pulled apart the deeply nested classes. I changed the anchor tag to only encompass the title instead of the whole card. I simplified and/or removed some CSS selectors. I fiddled with the focus styles a little. I changed the h2 of the card to an h3.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

Tested for responsiveness. 

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Check if everything looks okay. 
- After PR #375 is merged, the breadcrumb and assignments page content should be aligned on every screen width.