### PR TITLE
Fix: add hyphens auto to links #309

### DIFF
--- a/src/lib/components/organisms/PillarsComponent.svelte
+++ b/src/lib/components/organisms/PillarsComponent.svelte
@@ -82,7 +82,7 @@
 		align-items: center;
 		list-style: none;
 
-		@media (min-width: 600px) {
+		@media (min-width: 45rem) {
 			flex-direction: row;
 			align-items: unset;
 		}
@@ -99,7 +99,7 @@
 		width: 100%;
 		overflow: hidden;
 
-		@media (min-width: 600px) {
+		@media (min-width: 45rem) {
 			display: flex;
 			align-items: center;
 
@@ -120,7 +120,7 @@
 		position: relative;
 		z-index: -1;
 
-		@media (min-width: 600px) {
+		@media (min-width: 45rem) {
 			max-height: unset;
 			max-width: unset;
 		}
@@ -138,7 +138,7 @@
 		align-items: center;
 		justify-content: center;
 
-		@media (min-width: 600px) {
+		@media (min-width: 45rem) {
 			padding-block-start: 1em;
 			padding-block-end: 1em;
 			padding-inline: 0.5em;
@@ -151,7 +151,7 @@
 	.pillar:focus-within {
 		text-decoration: underline;
 
-		@media (min-width: 600px) and (prefers-reduced-motion: no-preference) {
+		@media (min-width: 45rem) and (prefers-reduced-motion: no-preference) {
 			img {
 				transform: scale(1.15);
 			}

--- a/src/lib/components/organisms/PillarsComponent.svelte
+++ b/src/lib/components/organisms/PillarsComponent.svelte
@@ -132,6 +132,7 @@
 		width: 100%;
 		height: 100%;
 		background-color: #292e6b;
+		hyphens: auto;
 
 		display: flex;
 		align-items: center;
@@ -140,9 +141,9 @@
 		@media (min-width: 600px) {
 			padding-block-start: 1em;
 			padding-block-end: 1em;
+			padding-inline: 0.5em;
 			font-size: unset;
-			text-wrap: nowrap;
-			height: auto;
+			height: 3lh;
 		}
 	}
 


### PR DESCRIPTION
## What does this change?

Resolves issue #309. I resolved this by allowing the browser to hyphenate the words. This is only one of a few possible solutions.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="683" height="265" alt="image" src="https://github.com/user-attachments/assets/bedf33ba-5b50-4959-81fa-305ce973ec7b" />
<img width="585" height="258" alt="image" src="https://github.com/user-attachments/assets/82da6158-66d3-4fa4-8e53-e63ca77f7ceb" />


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Let me know if you actually like this solution. We can also just adjust the breakpoint - or do a combination of both 😊