### PR TITLE
progressively enhance scroll rocket

### DIFF
--- a/src/lib/components/molecules/ScrollRocket.svelte
+++ b/src/lib/components/molecules/ScrollRocket.svelte
@@ -40,7 +40,7 @@
 
 		/* if animation timeline is supported, show the rocket */
 		@supports (animation-timeline: scroll(root)) {
-		display: block;		
+			display: block;
 		}
 	}
 
@@ -145,8 +145,6 @@
 			width: 40px;
 		}
 	}
-
-
 
 	/* Prefers Reduced Motion */
 	@media (prefers-reduced-motion: reduce) {

--- a/src/lib/components/molecules/ScrollRocket.svelte
+++ b/src/lib/components/molecules/ScrollRocket.svelte
@@ -34,8 +34,14 @@
 		width: 40px;
 		pointer-events: none;
 		z-index: 1;
+		display: none;
 
 		view-transition-name: scroll-track;
+
+		/* if animation timeline is supported, show the rocket */
+		@supports (animation-timeline: scroll(root)) {
+		display: block;		
+		}
 	}
 
 	@media (min-width: 768px) {
@@ -139,6 +145,8 @@
 			width: 40px;
 		}
 	}
+
+
 
 	/* Prefers Reduced Motion */
 	@media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## What does this change?

Resolves issue #414; the scroll rocket was stuck on the bottom, not scrolling with the scrollbar on firefox. This was because animation-timelines aren't supported yet on FireFox. So I elected to progressively enhance this feature by hiding the entire scroll rocket if the user happens to be on a browser that does not support animation timelines.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [x] [Progressive Enhancement test]() 
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
