### PR TITLE
408 user story scientific testimonial rework

### DIFF
--- a/src/lib/components/molecules/MissionTestimonial.svelte
+++ b/src/lib/components/molecules/MissionTestimonial.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <li>
-	<blockquote>{testimonial.text}</blockquote>
+	<blockquote class="paragraph">{testimonial.text}</blockquote>
 	<div>
 		<img src={testimonial.image} alt="" width="200" />
 		<div>
@@ -30,6 +30,7 @@
 		padding: 2rem 2rem 3rem 2.5rem;
 		background-color: var(--secondary-color, hsl(235, 45%, 29%));
 		border-radius: 0.5rem;
+		line-height: 1.3;
 
 		&::before {
 			content: '🙶' / '';
@@ -40,6 +41,7 @@
 	blockquote + div {
 		display: flex;
 		flex-direction: column;
+		align-items: center;
 		position: relative;
 		padding: 1rem;
 		margin-inline: 2rem;
@@ -50,7 +52,6 @@
 
 		@container (width > 20rem) {
 			flex-direction: row;
-			align-items: center;
 		}
 	}
 
@@ -63,10 +64,10 @@
 
 		@container (width > 20rem) {
 			position: absolute;
-			height: calc(100% + 1rem);
+			height: calc(100% + 2rem);
 			left: -1rem;
-			top: -0.5rem;
-			bottom: -0.5rem;
+			top: -1rem;
+			bottom: -1rem;
 		}
 	}
 

--- a/src/lib/components/molecules/MissionTestimonial.svelte
+++ b/src/lib/components/molecules/MissionTestimonial.svelte
@@ -4,15 +4,88 @@
 
 <li>
 	<blockquote>{testimonial.text}</blockquote>
-	<p>{testimonial.name}</p>
-	<p>{testimonial.title}</p>
-	<img src={testimonial.image} alt="" width="200" />
+	<div class="testimonial-person">
+		<img src={testimonial.image} alt="" width="200" />
+		<div>
+			<p class="testimonial-name">{testimonial.name}</p>
+			<p>{testimonial.title}</p>
+		</div>
+	</div>
 </li>
 
 <style>
+	li {
+		display: flex;
+		flex-direction: column;
+		grid-template-rows: 1fr 3rem;
+		container-type: inline-size;
+	}
+
+	blockquote {
+		background-color: var(--secondary-color, hsl(235, 45%, 29%));
+		padding: 2rem;
+		padding-inline-start: 3rem;
+		padding-block-end: 3rem;
+		border-radius: 0.5rem;
+		font-size: 1rem;
+		display: flex;
+
+		&::before {
+			content: '🙶' / '';
+			font-size: 2rem;
+			position: relative;
+			transform: translateX(-50%);
+		}
+	}
+
+	.testimonial-person {
+		background-color: var(--background-color-light, white);
+		color: var(--text-color-dark, black);
+		border: var(--background-color-dark, black);
+		padding: 1rem;
+		border-radius: 0.5rem;
+		margin-inline: 2rem;
+		margin-block-start: -1rem;
+		display: flex;
+		flex-direction: column;
+		position: relative;
+		align-items: center;
+
+		@container (width > 20rem) {
+			flex-direction: row;
+		}
+	}
+
+	p {
+		font-family: spaceMonoRegular, monospace;
+		letter-spacing: -0.2px;
+		padding: 0.25rem;
+		text-align: center;
+
+		@container (width > 20rem) {
+			text-align: unset;
+			padding-inline-start: 7rem;
+		}
+	}
+
+	.testimonial-name {
+		font-weight: bold;
+		letter-spacing: 0.4px;
+	}
+
 	img {
-		height: 8rem;
-		width: 8rem;
+		height: 100%;
+		max-width: 8rem;
+		aspect-ratio: 1 / 1;
 		object-fit: cover;
+		border-radius: 0.5rem;
+
+		@container (width > 20rem) {
+			position: absolute;
+			left: -1rem;
+			height: calc(100% + 1rem);
+			top: -0.5rem;
+			bottom: -0.5rem;
+		}
 	}
 </style>

--- a/src/lib/components/molecules/MissionTestimonial.svelte
+++ b/src/lib/components/molecules/MissionTestimonial.svelte
@@ -4,10 +4,10 @@
 
 <li>
 	<blockquote>{testimonial.text}</blockquote>
-	<div class="testimonial-person">
+	<div>
 		<img src={testimonial.image} alt="" width="200" />
 		<div>
-			<p class="testimonial-name">{testimonial.name}</p>
+			<p>{testimonial.name}</p>
 			<p>{testimonial.title}</p>
 		</div>
 	</div>
@@ -37,7 +37,7 @@
 		}
 	}
 
-	.testimonial-person {
+	blockquote + div {
 		display: flex;
 		flex-direction: column;
 		position: relative;
@@ -52,23 +52,6 @@
 			flex-direction: row;
 			align-items: center;
 		}
-	}
-
-	p {
-		padding: 0.25rem;
-		font-family: spaceMonoRegular, monospace;
-		letter-spacing: -0.2px;
-		text-align: center;
-
-		@container (width > 20rem) {
-			text-align: unset;
-			padding-inline-start: 7rem;
-		}
-	}
-
-	.testimonial-name {
-		font-weight: bold;
-		letter-spacing: 0.4px;
 	}
 
 	img {
@@ -86,4 +69,22 @@
 			bottom: -0.5rem;
 		}
 	}
+
+	p {
+		padding: 0.25rem;
+		font-family: spaceMonoRegular, monospace;
+		letter-spacing: -0.2px;
+		text-align: center;
+
+		&:first-of-type {
+			font-weight: bold;
+			letter-spacing: 0.4px;
+		}
+
+		@container (width > 20rem) {
+			text-align: unset;
+			padding-inline-start: 7rem;
+		}
+	}
+	
 </style>

--- a/src/lib/components/molecules/MissionTestimonial.svelte
+++ b/src/lib/components/molecules/MissionTestimonial.svelte
@@ -1,0 +1,18 @@
+<script>
+	let { testimonial } = $props()
+</script>
+
+<li>
+	<blockquote>{testimonial.text}</blockquote>
+	<p>{testimonial.name}</p>
+	<p>{testimonial.title}</p>
+	<img src={testimonial.image} alt="" width="200" />
+</li>
+
+<style>
+	img {
+		height: 8rem;
+		width: 8rem;
+		object-fit: cover;
+	}
+</style>

--- a/src/lib/components/molecules/MissionTestimonial.svelte
+++ b/src/lib/components/molecules/MissionTestimonial.svelte
@@ -30,7 +30,7 @@
 		padding: 2rem 2rem 3rem 2.5rem;
 		background-color: var(--secondary-color, hsl(235, 45%, 29%));
 		border-radius: 0.5rem;
-		
+
 		&::before {
 			content: '🙶' / '';
 			font-size: 2rem;
@@ -47,7 +47,7 @@
 		background-color: var(--background-color-light, white);
 		color: var(--text-color-dark, black);
 		border-radius: 0.5rem;
-	
+
 		@container (width > 20rem) {
 			flex-direction: row;
 			align-items: center;
@@ -86,5 +86,4 @@
 			padding-inline-start: 7rem;
 		}
 	}
-	
 </style>

--- a/src/lib/components/molecules/MissionTestimonial.svelte
+++ b/src/lib/components/molecules/MissionTestimonial.svelte
@@ -17,49 +17,47 @@
 	li {
 		display: flex;
 		flex-direction: column;
-		grid-template-rows: 1fr 3rem;
 		container-type: inline-size;
+
+		&:nth-of-type(even) blockquote {
+			background-color: var(--accent-color-dark, hsl(14, 83%, 52%));
+		}
 	}
 
 	blockquote {
-		background-color: var(--secondary-color, hsl(235, 45%, 29%));
-		padding: 2rem;
-		padding-inline-start: 3rem;
-		padding-block-end: 3rem;
-		border-radius: 0.5rem;
-		font-size: 1rem;
 		display: flex;
-
+		gap: 0.5rem;
+		padding: 2rem 2rem 3rem 2.5rem;
+		background-color: var(--secondary-color, hsl(235, 45%, 29%));
+		border-radius: 0.5rem;
+		
 		&::before {
 			content: '🙶' / '';
 			font-size: 2rem;
-			position: relative;
-			transform: translateX(-50%);
 		}
 	}
 
 	.testimonial-person {
-		background-color: var(--background-color-light, white);
-		color: var(--text-color-dark, black);
-		border: var(--background-color-dark, black);
-		padding: 1rem;
-		border-radius: 0.5rem;
-		margin-inline: 2rem;
-		margin-block-start: -1rem;
 		display: flex;
 		flex-direction: column;
 		position: relative;
-		align-items: center;
-
+		padding: 1rem;
+		margin-inline: 2rem;
+		margin-block-start: -1rem;
+		background-color: var(--background-color-light, white);
+		color: var(--text-color-dark, black);
+		border-radius: 0.5rem;
+	
 		@container (width > 20rem) {
 			flex-direction: row;
+			align-items: center;
 		}
 	}
 
 	p {
+		padding: 0.25rem;
 		font-family: spaceMonoRegular, monospace;
 		letter-spacing: -0.2px;
-		padding: 0.25rem;
 		text-align: center;
 
 		@container (width > 20rem) {
@@ -82,8 +80,8 @@
 
 		@container (width > 20rem) {
 			position: absolute;
-			left: -1rem;
 			height: calc(100% + 1rem);
+			left: -1rem;
 			top: -0.5rem;
 			bottom: -0.5rem;
 		}

--- a/src/lib/components/organisms/TestimonialCollection.svelte
+++ b/src/lib/components/organisms/TestimonialCollection.svelte
@@ -1,0 +1,33 @@
+<script>
+	import { mertenImage, MissionTestimonial } from '$lib'
+
+	const data = [
+		{
+			text: 'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iure vel eaque, distinctio deserunt minus perspiciatis vero cum quasi voluptate ad fuga nesciunt eligendi sunt unde repellendus molestias non sequi officiis!',
+			name: 'Martin Grim',
+			title: 'Section Head Electronics Engineering',
+			image: mertenImage,
+		},
+		{
+			text: 'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iure vel eaque, distinctio deserunt minus perspiciati.',
+			name: 'Martin Grim',
+			title: 'Section Head Electronics Engineering',
+			image: mertenImage,
+		},
+		{
+			text: 'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iure vel eaque, distinctio deserunt minus perspiciatis vero cum quasi voluptate ad fuga nesciunt eligendi sunt.',
+			name: 'Martin Grim',
+			title: 'Section Head Electronics Engineering',
+			image: mertenImage,
+		},
+	]
+</script>
+
+<ul>
+	{#each data as testimonial (testimonial.text)}
+		<MissionTestimonial {testimonial} />
+	{/each}
+</ul>
+
+<style>
+</style>

--- a/src/lib/components/organisms/TestimonialCollection.svelte
+++ b/src/lib/components/organisms/TestimonialCollection.svelte
@@ -1,17 +1,17 @@
 <script>
-	import { mertenImage, MissionTestimonial } from '$lib'
+	import { mertenImage, rushilImage, MissionTestimonial } from '$lib'
 
 	const data = [
 		{
-			text: 'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iure vel eaque, distinctio deserunt minus perspiciatis vero cum quasi voluptate ad fuga nesciunt eligendi sunt unde repellendus molestias non sequi officiis!',
-			name: 'Martin Grim',
-			title: 'Section Head Electronics Engineering',
-			image: mertenImage,
+			text: 'The project all corporate projects wish they could be. The place where agile is actually agile. Heed my words dear reader, this project will serve as valuable experience of the things that can be done right. This was as great experience!',
+			name: 'Rushil Varsnney',
+			title: 'Aero Space Engineering, TU Delft',
+			image: rushilImage,
 		},
 		{
-			text: 'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iure vel eaque, distinctio deserunt minus perspiciati.',
-			name: 'Martin Grim',
-			title: 'Section Head Electronics Engineering',
+			text: "Doing my JIP was a great experience. It really helped that although the JIP and NEBULA-Xplorer team all came from different backgrounds, they all brought the same energy. One meeting I was learning how one previous assumption in power usage can completely change the current concept, and other times I was the one walking everyone through our approach on the system architecture. And knowing that you're working on a real telescope that will actually be launched, is really motivating. I now have the opportunity to start my thesis here as well!",
+			name: 'Merten Tijsma',
+			title: 'Aero Space Engineering, TU Delft',
 			image: mertenImage,
 		},
 		{

--- a/src/lib/components/organisms/TestimonialCollection.svelte
+++ b/src/lib/components/organisms/TestimonialCollection.svelte
@@ -34,7 +34,7 @@
 
 <style>
 	section {
-		margin-block: calc(2rem + 2vw);
+		margin-block-end: calc(2rem + 2vw);
 	}
 
 	h2 {
@@ -47,8 +47,8 @@
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
 		gap: 2rem;
-		list-style: none;
 		max-width: var(--content-width);
 		margin-inline: auto;
+		list-style: none;
 	}
 </style>

--- a/src/lib/components/organisms/TestimonialCollection.svelte
+++ b/src/lib/components/organisms/TestimonialCollection.svelte
@@ -23,11 +23,32 @@
 	]
 </script>
 
-<ul>
-	{#each data as testimonial (testimonial.text)}
-		<MissionTestimonial {testimonial} />
-	{/each}
-</ul>
+<section>
+	<h2 class="heading">What our experts say</h2>
+	<ul>
+		{#each data as testimonial (testimonial.text)}
+			<MissionTestimonial {testimonial} />
+		{/each}
+	</ul>
+</section>
 
 <style>
+	section {
+		margin-block: calc(2rem + 2vw);
+	}
+
+	h2 {
+		max-width: var(--content-width);
+		margin-inline: auto;
+		margin-block-end: 1em;
+	}
+
+	ul {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+		gap: 2rem;
+		list-style: none;
+		max-width: var(--content-width);
+		margin-inline: auto;
+	}
 </style>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -8,6 +8,7 @@ export { default as NewsComponent } from './components/organisms/NewsComponent.s
 export { default as PartnersCarousel } from './components/organisms/PartnersCarousel.svelte'
 export { default as PillarsComponent } from './components/organisms/PillarsComponent.svelte'
 export { default as TeamsYearComponent } from '$lib/components/organisms/TeamsYearComponent.svelte'
+export { default as TestimonialCollection } from '$lib/components/organisms/TestimonialCollection.svelte'
 export { default as MissionGoals } from './components/organisms/MissionGoals.svelte'
 export { default as Timeline } from './components/organisms/Timeline.svelte'
 
@@ -18,6 +19,7 @@ export { default as CarouselTrack } from './components/molecules/CarouselTrack.s
 export { default as FooterLocations } from './components/molecules/FooterLocations.svelte'
 export { default as FooterNav } from './components/molecules/FooterNav.svelte'
 export { default as MailingListSignup } from './components/molecules/MailingListSignup.svelte'
+export { default as MissionTestimonial } from './components/molecules/MissionTestimonial.svelte'
 export { default as Pagination } from './components/molecules/Pagination.svelte'
 export { default as ScientificTestimonial } from './components/molecules/ScientificTestimonial.svelte'
 export { default as Sponsors } from './components/molecules/Sponsors.svelte'

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -2,11 +2,11 @@
 	import {
 		Hero,
 		Breadcrumb,
+		MissionGoals,
 		Timeline,
 		TestimonialCollection,
 		blackholeEnhanced as blackholeImage,
 	} from '$lib'
-	import MissionGoals from '$lib/components/organisms/MissionGoals.svelte'
 </script>
 
 <svelte:head>
@@ -142,7 +142,6 @@
 
 <MissionGoals />
 
-<!-- STEPS BLOCK -->
 <Timeline />
 
 <TestimonialCollection />
@@ -235,10 +234,6 @@
 	}
 
 	/* util classes */
-	.orange {
-		color: var(--cleanroom-100);
-	}
-
 	:global(enhanced\:img) {
 		width: auto;
 	}

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -3,7 +3,7 @@
 		Hero,
 		Breadcrumb,
 		Timeline,
-		ScientificTestimonial,
+		TestimonialCollection,
 		blackholeEnhanced as blackholeImage,
 	} from '$lib'
 	import MissionGoals from '$lib/components/organisms/MissionGoals.svelte'
@@ -145,7 +145,7 @@
 <!-- STEPS BLOCK -->
 <Timeline />
 
-<ScientificTestimonial />
+<TestimonialCollection />
 
 <style>
 	.paragraph-block div {


### PR DESCRIPTION
## What does this change?

Resolves issue #408. 
- Adds two new components, TestimonialCollection and MissionTestimonial. 
- TestimonialCollection has some dummy data and three instances of MissionTestimonial.
- Each testimonial displays a quote, a picture, and a person's name and title. 
- Each even-numbered testimonial is orange.
- Uses custom variables to be introduced in #417

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->
**Responsive**: tested from 250px to 2000px.
**Browser**: tested in Chrome and Firefox
**Accessibility**: no keyboard test because no interactable elements. Screen reader correctly ignores the quote icon. 

### RAPPE Principles

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="1315" height="419" alt="image" src="https://github.com/user-attachments/assets/e713468e-df71-468d-96df-80d6b9359d8e" />


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Check if it works on your device/browser
- Check if the code looks good and if anything can be improved
- Let me know if you like it! 
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 