### PR TITLE
422 add more info to mission goals section

### DIFF
--- a/src/lib/components/organisms/MissionGoals.svelte
+++ b/src/lib/components/organisms/MissionGoals.svelte
@@ -3,7 +3,6 @@
 </script>
 
 <section class="goals-block" class:dark={colorScheme === 'dark'}>
-	<h2 class="visually-hidden">Mission Goals</h2>
 	<div class="content-container">
 		<div class="goals-grid">
 			<section class="goal-box">

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -299,29 +299,29 @@
 		}
 	}
 
-	.mission-combined {
-		background-color: var(--background-color-light);
-		color: var(--text-color-dark);
-	}
+.mission-combined {
+	background-color: var(--background-color-light);
+	color: var(--text-color-dark);
+}
 
-	.paragraph-block-alt h3.orange-on-white.heading {
+.paragraph-block-alt {
+	h3.orange-on-white.heading {
 		font-size: 1.5rem;
 		font-weight: 500;
 		display: flex;
 		gap: 1rem;
-	}
 
-	.paragraph-block-alt .text-content {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-
-	@media (min-width: 36.25rem) {
-		.paragraph-block-alt h3.orange-on-white.heading {
+		@media (min-width: 36.25rem) {
 			gap: 2rem;
 		}
 	}
+
+	.text-content {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+	}
+}
 
 	/* util classes */
 	:global(enhanced\:img) {

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -299,29 +299,29 @@
 		}
 	}
 
-.mission-combined {
-	background-color: var(--background-color-light);
-	color: var(--text-color-dark);
-}
+	.mission-combined {
+		background-color: var(--background-color-light);
+		color: var(--text-color-dark);
+	}
 
-.paragraph-block-alt {
-	h3.orange-on-white.heading {
-		font-size: 1.5rem;
-		font-weight: 500;
-		display: flex;
-		gap: 1rem;
+	.paragraph-block-alt {
+		h3.orange-on-white.heading {
+			font-size: 1.5rem;
+			font-weight: 500;
+			display: flex;
+			gap: 1rem;
 
-		@media (min-width: 36.25rem) {
-			gap: 2rem;
+			@media (min-width: 36.25rem) {
+				gap: 2rem;
+			}
+		}
+
+		.text-content {
+			display: flex;
+			flex-direction: column;
+			gap: 1.5rem;
 		}
 	}
-
-	.text-content {
-		display: flex;
-		flex-direction: column;
-		gap: 1.5rem;
-	}
-}
 
 	/* util classes */
 	:global(enhanced\:img) {

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -166,11 +166,11 @@
 	</div>
 </section>
 
-<section class="mission-combined">
-	<h2 class="sr-only">Mission Goals</h2>
-	<MissionGoals />
+<!-- FOURTH PARAGRAPH + IMG BLOCK -->
 
-	<!-- Fourth PARAGRAPH + IMG BLOCK -->
+<section class="mission-combined">
+	<h2 class="visually-hidden">Mission Goals</h2>
+	<MissionGoals />
 
 	<section class="paragraph-block paragraph-block-alt">
 		<div class="content-container">
@@ -341,18 +341,6 @@
 				gap: 2rem;
 			}
 		}
-	}
-
-	.sr-only {
-		position: absolute;
-		width: 1px;
-		height: 1px;
-		padding: 0;
-		margin: -1px;
-		overflow: hidden;
-		clip: rect(0, 0, 0, 0);
-		white-space: nowrap;
-		border: 0;
 	}
 
 	.mission-list {

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -151,12 +151,13 @@
 	</div>
 </section>
 
-<MissionGoals />
+<section class="mission-combined">
+	<MissionGoals />
 
-<!-- Fourth PARAGRAPH + IMG BLOCK -->
-<section class="paragraph-block paragraph-block-alt">
-<div class="content-container">
-		<section class="text-content">
+	<!-- Fourth PARAGRAPH + IMG BLOCK -->
+	<section class="paragraph-block paragraph-block-alt">
+		<div class="content-container">
+			<section class="text-content">
 				<h3 class="orange-on-white heading">
 					<span>01</span>
 					<span>X-ray Binary Mysteries</span>
@@ -166,11 +167,11 @@
 					Many of the brightest objects in the Universe are X-ray
 					binaries — combinations of an extremely compact object, such
 					as a black hole or neutron star, and a companion star. Over
-					time, the compact object strips matter from its companion, releasing
-					enormous energy in a focused beam called a jet. Scientists do not yet
-					fully understand this process, and the behaviour of matter right at
-					the edge of the black hole remains one of the great mysteries of
-					modern astrophysics.
+					time, the compact object strips matter from its companion,
+					releasing enormous energy in a focused beam called a jet.
+					Scientists do not yet fully understand this process, and the
+					behaviour of matter right at the edge of the black hole
+					remains one of the great mysteries of modern astrophysics.
 				</p>
 
 				<h3 class="orange-on-white heading">
@@ -181,10 +182,11 @@
 				<p>
 					NEBULA – Xplorer will investigate how jets form and how
 					X-ray binaries evolve by observing these objects over
-					extended periods — tracking how their emissions vary across timescales
-					ranging from milliseconds to weeks. These long observation
-					windows make it possible to combine X-ray data with measurements
-					from other telescopes across different wavelengths.
+					extended periods — tracking how their emissions vary across
+					timescales ranging from milliseconds to weeks. These long
+					observation windows make it possible to combine X-ray data
+					with measurements from other telescopes across different
+					wavelengths.
 				</p>
 
 				<h3 class="orange-on-white heading">
@@ -194,14 +196,16 @@
 
 				<p>
 					Every six months, a new cohort of students from different
-					disciplines —  including astrophysics, spacecraft engineering,
-					optics, electronics, software, and communications — joins the
-					project. Each group builds on the work of the last, with
-					continuity ensured by SRON scientists and industry partners.
+					disciplines — including astrophysics, spacecraft
+					engineering, optics, electronics, software, and
+					communications — joins the project. Each group builds on the
+					work of the last, with continuity ensured by SRON scientists
+					and industry partners.
 				</p>
-		</section>
-		<enhanced:img src={blackholeImage} alt="Black Hole" />
-	</div>
+			</section>
+			<enhanced:img src={blackholeImage} alt="Black Hole" />
+		</div>
+	</section>
 </section>
 
 <Timeline />
@@ -295,6 +299,30 @@
 		}
 	}
 
+	.mission-combined {
+		background-color: var(--background-color-light);
+		color: var(--text-color-dark);
+	}
+
+	.paragraph-block-alt h3.orange-on-white.heading {
+		font-size: 1.5rem;
+		font-weight: 500;
+		display: flex;
+		gap: 1rem;
+	}
+
+	.paragraph-block-alt .text-content {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	@media (min-width: 36.25rem) {
+		.paragraph-block-alt h3.orange-on-white.heading {
+			gap: 2rem;
+		}
+	}
+
 	/* util classes */
 	:global(enhanced\:img) {
 		width: auto;
@@ -305,6 +333,4 @@
 		font-weight: 600;
 		line-height: 1.5;
 	}
-
-	
 </style>

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -12,21 +12,25 @@
 
 <svelte:head>
 	<title>Mission</title>
+
 	<meta
 		name="description"
 		content="NEBULA-Xplorer will investigate how jets form and how X-ray binaries evolve. It will observe these objects for long periods of time to see how their emission varies on time scales from milliseconds to weeks." />
 </svelte:head>
 
 <!-- HERO BLOCK -->
+
 <Hero
 	titleColor="var(--text-color-light)"
 	background={{
 		file: tarantulaMergerEnhanced,
+
 		alt: 'Visualization of a Black Hole Merger in the Tarantula Nebula',
 	}}
 	pageTitle="Mission"
 	attribution={{
 		text: 'NASA',
+
 		link: 'https://apod.nasa.gov/apod/ap260403.html',
 	}} />
 
@@ -39,6 +43,7 @@
 		<h2 class="subtitle">
 			What are we <span class="orange">up</span> to?
 		</h2>
+
 		<p class="heading">What our current project entails</p>
 	</div>
 </hgroup>
@@ -47,6 +52,7 @@
 	<div class="content-container">
 		<section class="text-content">
 			<h3 class="orange heading">Dense matter and compact objects</h3>
+
 			<p>
 				NEBULA-Xplorer will investigate compact objects such as neutron
 				stars and black hole X-ray binaries within our Milky Way. By
@@ -59,6 +65,7 @@
 				systems, where light is most affected by the gravity of compact
 				objects and the magnetic environment of neutron stars.
 			</p>
+
 			<p>
 				By observing black holes in this energy range, we can also
 				measure the spin of black holes by observing the relativistic
@@ -70,6 +77,7 @@
 				estimated to make up to 85% of star systems in our universe.
 			</p>
 		</section>
+
 		<enhanced:img src={blackholeImage} alt="Black Hole" />
 	</div>
 </section>
@@ -82,8 +90,10 @@
 			class="paragraph-img-left"
 			src={blackholeImage}
 			alt="Black Hole" />
+
 		<section class="text-content">
 			<h3 class="orange-on-white heading">Multi-messenger physics</h3>
+
 			<p>
 				NEBULA-Xplorer frames the multi-wavelength campaigns required to
 				understand jet and accretion physics at the forefront of its
@@ -93,6 +103,7 @@
 				ability to maintain as close to continuous observations of
 				targets as possible.
 			</p>
+
 			<p>
 				During longer observations, NEBULA-Xplorer will transmit timing
 				information key to understanding when ballistic jet ejections
@@ -114,6 +125,7 @@
 	<div class="content-container">
 		<section class="text-content">
 			<h3 class="orange heading">Time-domain Astrophysics</h3>
+
 			<p>
 				As a non-imaging X-ray timing observatory, NEBULA-Xplorer’s core
 				science focuses on interpreting the variability of emission from
@@ -126,6 +138,7 @@
 				disk and companion star in these systems obscuring the central
 				accretion engine.
 			</p>
+
 			<p>
 				Frequently, changes in variability are affected by multiple
 				phenomena in the system that evolve on different time scales,
@@ -136,6 +149,7 @@
 				will allow us to understand the short-term variability of
 				emission and how that changes on timescales of days to weeks.
 			</p>
+
 			<p>
 				NEBULA-Xplorer’s moderate energy resolution and high timing
 				resolution will also allow us to perform spectral-timing
@@ -147,62 +161,74 @@
 				of light travel time within the system.
 			</p>
 		</section>
+
 		<enhanced:img src={blackholeImage} alt="Black Hole" />
 	</div>
 </section>
 
 <section class="mission-combined">
+	<h2 class="sr-only">Mission Goals</h2>
 	<MissionGoals />
 
 	<!-- Fourth PARAGRAPH + IMG BLOCK -->
+
 	<section class="paragraph-block paragraph-block-alt">
 		<div class="content-container">
-			<section class="text-content">
-				<h3 class="orange-on-white heading">
-					<span>01</span>
-					<span>X-ray Binary Mysteries</span>
-				</h3>
+			<ol class="text-content mission-list">
+				<li>
+					<h3 class="orange-on-white heading">
+						<span>01</span>
 
-				<p>
-					Many of the brightest objects in the Universe are X-ray
-					binaries — combinations of an extremely compact object, such
-					as a black hole or neutron star, and a companion star. Over
-					time, the compact object strips matter from its companion,
-					releasing enormous energy in a focused beam called a jet.
-					Scientists do not yet fully understand this process, and the
-					behaviour of matter right at the edge of the black hole
-					remains one of the great mysteries of modern astrophysics.
-				</p>
+						<span>X-ray Binary Mysteries</span>
+					</h3>
 
-				<h3 class="orange-on-white heading">
-					<span>02</span>
-					<span>Long-Duration Observations</span>
-				</h3>
+					<p>
+						Many of the brightest objects in the Universe are X-ray
+						binaries — combinations of an extremely compact object,
+						such as a black hole or neutron star, and a companion
+						star. Over time, the compact object strips matter from
+						its companion, releasing enormous energy in a focused
+						beam called a jet. Scientists do not yet fully
+						understand this process, and the behaviour of matter
+						right at the edge of the black hole remains one of the
+						great mysteries of modern astrophysics.
+					</p>
+				</li>
+				<li>
+					<h3 class="orange-on-white heading">
+						<span>02</span>
 
-				<p>
-					NEBULA – Xplorer will investigate how jets form and how
-					X-ray binaries evolve by observing these objects over
-					extended periods — tracking how their emissions vary across
-					timescales ranging from milliseconds to weeks. These long
-					observation windows make it possible to combine X-ray data
-					with measurements from other telescopes across different
-					wavelengths.
-				</p>
+						<span>Long-Duration Observations</span>
+					</h3>
 
-				<h3 class="orange-on-white heading">
-					<span>03</span>
-					<span>Training the Next Generation</span>
-				</h3>
+					<p>
+						NEBULA – Xplorer will investigate how jets form and how
+						X-ray binaries evolve by observing these objects over
+						extended periods — tracking how their emissions vary
+						across timescales ranging from milliseconds to weeks.
+						These long observation windows make it possible to
+						combine X-ray data with measurements from other
+						telescopes across different wavelengths.
+					</p>
+				</li>
+				<li>
+					<h3 class="orange-on-white heading">
+						<span>03</span>
 
-				<p>
-					Every six months, a new cohort of students from different
-					disciplines — including astrophysics, spacecraft
-					engineering, optics, electronics, software, and
-					communications — joins the project. Each group builds on the
-					work of the last, with continuity ensured by SRON scientists
-					and industry partners.
-				</p>
-			</section>
+						<span>Training the Next Generation</span>
+					</h3>
+
+					<p>
+						Every six months, a new cohort of students from
+						different disciplines — including astrophysics,
+						spacecraft engineering, optics, electronics, software,
+						and communications — joins the project. Each group
+						builds on the work of the last, with continuity ensured
+						by SRON scientists and industry partners.
+					</p>
+				</li>
+			</ol>
+
 			<enhanced:img src={blackholeImage} alt="Black Hole" />
 		</div>
 	</section>
@@ -304,8 +330,8 @@
 		color: var(--text-color-dark);
 	}
 
-	.paragraph-block-alt {
-		h3.orange-on-white.heading {
+	.mission-combined {
+		h3 {
 			font-size: 1.5rem;
 			font-weight: 500;
 			display: flex;
@@ -315,12 +341,31 @@
 				gap: 2rem;
 			}
 		}
+	}
 
-		.text-content {
-			display: flex;
-			flex-direction: column;
-			gap: 1.5rem;
-		}
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	.mission-list {
+		padding: 0;
+		margin: 0;
+		list-style: none;
+		display: grid;
+		gap: 2rem;
+	}
+
+	.mission-list li {
+		display: grid;
+		gap: 0.75rem;
 	}
 
 	/* util classes */

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -153,6 +153,57 @@
 
 <MissionGoals />
 
+<!-- Fourth PARAGRAPH + IMG BLOCK -->
+<section class="paragraph-block paragraph-block-alt">
+<div class="content-container">
+		<section class="text-content">
+				<h3 class="orange-on-white heading">
+					<span>01</span>
+					<span>X-ray Binary Mysteries</span>
+				</h3>
+
+				<p>
+					Many of the brightest objects in the Universe are X-ray
+					binaries — combinations of an extremely compact object, such
+					as a black hole or neutron star, and a companion star. Over
+					time, the compact object strips matter from its companion, releasing
+					enormous energy in a focused beam called a jet. Scientists do not yet
+					fully understand this process, and the behaviour of matter right at
+					the edge of the black hole remains one of the great mysteries of
+					modern astrophysics.
+				</p>
+
+				<h3 class="orange-on-white heading">
+					<span>02</span>
+					<span>Long-Duration Observations</span>
+				</h3>
+
+				<p>
+					NEBULA – Xplorer will investigate how jets form and how
+					X-ray binaries evolve by observing these objects over
+					extended periods — tracking how their emissions vary across timescales
+					ranging from milliseconds to weeks. These long observation
+					windows make it possible to combine X-ray data with measurements
+					from other telescopes across different wavelengths.
+				</p>
+
+				<h3 class="orange-on-white heading">
+					<span>03</span>
+					<span>Training the Next Generation</span>
+				</h3>
+
+				<p>
+					Every six months, a new cohort of students from different
+					disciplines —  including astrophysics, spacecraft engineering,
+					optics, electronics, software, and communications — joins the
+					project. Each group builds on the work of the last, with
+					continuity ensured by SRON scientists and industry partners.
+				</p>
+		</section>
+		<enhanced:img src={blackholeImage} alt="Black Hole" />
+	</div>
+</section>
+
 <Timeline />
 
 <TestimonialCollection />
@@ -254,4 +305,6 @@
 		font-weight: 600;
 		line-height: 1.5;
 	}
+
+	
 </style>


### PR DESCRIPTION
## What does this change?

Resolves issue #422

This PR adds new content to the **Mission Goals section** on the Mission page, as requested by the client.

The following three informational blocks were added:

- X-ray Binary Mysteries
- Long-Duration Observations
- Training the Next Generation

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Video

https://github.com/user-attachments/assets/bc2788aa-6560-4bd1-892b-753674b8f76

## How to review

- Open the Mission page
- Scroll to the Mission Goals section
- Verify that the three new blocks appear correctly
- Check spacing, alignment, and responsiveness
- Let me know if anything can be improved